### PR TITLE
Normalize user-scoped app rule names and improve test environment

### DIFF
--- a/custom_components/firewalla_local/api/client.py
+++ b/custom_components/firewalla_local/api/client.py
@@ -96,6 +96,7 @@ _RAW_RULE_DISABLED_KEY: Final = "disabled"
 _RAW_RULE_UPDATED_TIME_KEY: Final = "updatedTime"
 _RAW_RULE_IDLE_TS_KEY: Final = "idleTs"
 _RAW_RULE_TARGET_NAME_KEY: Final = "target_name"
+_RAW_RULE_APP_NAME_KEY: Final = "app_name"
 _RAW_RULE_ACTIVATED_TIME_KEY: Final = "activatedTime"
 _RAW_RULE_LAST_ACTIVATED_TIME_KEY: Final = "lastActivatedTime"
 _RAW_RULE_EXPIRE_KEY: Final = "expire"
@@ -1749,9 +1750,9 @@ class FirewallaApiClient:
             return None
 
         if tag_prefix == _RAW_TAG_PREFIX_GROUP:
+            if user_names := affiliated_users.get(tag_value):
+                return ", ".join(user_names)
             if tag_name := tags.get(tag_value):
-                if user_names := affiliated_users.get(tag_value):
-                    return f"{tag_name} ({', '.join(user_names)})"
                 return tag_name
             return None
         if tag_prefix == _RAW_TAG_PREFIX_DEVICE:
@@ -1841,6 +1842,9 @@ class FirewallaApiClient:
             return networks.get(target)
 
         if target_type == _RULE_TARGET_TYPE_CATEGORY:
+            app_name = raw_rule.get(_RAW_RULE_APP_NAME_KEY)
+            if isinstance(app_name, str) and app_name:
+                return app_name.replace("_", " ").title()
             if target in categories:
                 return categories[target]
             if target.startswith(_RULE_TARGET_LIST_PREFIX):

--- a/custom_components/firewalla_local/config_flow.py
+++ b/custom_components/firewalla_local/config_flow.py
@@ -171,7 +171,7 @@ def _resolve_default_pairing_host() -> str | None:
             family=socket.AF_INET,
             type=socket.SOCK_STREAM,
         )
-    except OSError:
+    except OSError, RuntimeError:
         return None
 
     for family, _socktype, _proto, _canonname, sockaddr in addrinfo:

--- a/custom_components/firewalla_local/manifest.json
+++ b/custom_components/firewalla_local/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/ccpk1/firewalla-local-ha/issues",
   "loggers": ["custom_components.firewalla_local"],
   "requirements": ["cryptography>=44.0.0"],
-  "version": "1.1.5"
+  "version": "1.1.6"
 }

--- a/custom_components/firewalla_local/models.py
+++ b/custom_components/firewalla_local/models.py
@@ -79,6 +79,7 @@ _INTERNAL_IDENTIFIER_SEPARATOR: Final = "-"
 _PRETTIFIED_TARGET_SEPARATOR: Final = "_"
 _PRETTIFIED_TARGET_REPLACEMENT: Final = " "
 _TARGET_LIST_PREFIX: Final = "TL-"
+_APP_CATEGORY_TARGET_PREFIX: Final = "TLX-"
 _WEEKDAY_LABELS: Final = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")
 _WEEKDAY_ORDER: Final = {
     weekday: index for index, weekday in enumerate(_WEEKDAY_LABELS)
@@ -1236,9 +1237,14 @@ def format_policy_rule_name(rule: FirewallaPolicyRule) -> str:
             RULE_TARGET_TYPE_NETWORK,
             RULE_TARGET_TYPE_CATEGORY,
         } and _looks_like_internal_identifier(rule.target)
+        target_is_internal_category_ref = (
+            rule.target_type == RULE_TARGET_TYPE_CATEGORY
+            and rule.target.startswith(_APP_CATEGORY_TARGET_PREFIX)
+        )
         if (
             rule.target_name.casefold() == prettified_target.casefold()
             or target_is_internal_id
+            or target_is_internal_category_ref
         ):
             display_target = rule.target_name
         elif rule.target_name != rule.target:

--- a/firewalla-dev.code-workspace
+++ b/firewalla-dev.code-workspace
@@ -58,7 +58,7 @@
       {
         "label": "Auto-Link Firewalla Local",
         "type": "shell",
-        "command": "mkdir -p /workspaces/core/config/custom_components && ln -snf /workspaces/firewalla-local-ha/custom_components/firewalla_local /workspaces/core/config/custom_components/firewalla_local",
+        "command": "mkdir -p /workspaces/core/config/custom_components && touch /workspaces/core/config/custom_components/__init__.py && ln -snf /workspaces/firewalla-local-ha/custom_components/firewalla_local /workspaces/core/config/custom_components/firewalla_local",
         "runOptions": {
           "runOn": "folderOpen",
         },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-firewalla-local"
-version = "1.1.5"
+version = "1.1.6"
 description = "Local-first Home Assistant custom integration for Firewalla"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/test_output.txt
+++ b/test_output.txt
@@ -1,0 +1,1124 @@
+============================= test session starts ==============================
+platform linux -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0 -- /home/vscode/.local/ha-venv/bin/python
+cachedir: .pytest_cache
+rootdir: /workspaces/firewalla-local-ha
+configfile: pyproject.toml
+plugins: github-actions-annotate-failures-0.4.0, syrupy-5.1.0, homeassistant-custom-component-0.13.330, typeguard-4.5.1, cov-7.1.0, respx-0.23.1, unordered-0.7.0, socket-0.7.0, requests-mock-1.12.1, asyncio-1.3.0, aiohttp-1.1.0, pytest_freezer-0.4.9, anyio-4.10.0, picked-0.5.1, sugar-1.0.0, xdist-3.8.0, timeout-2.4.0
+asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 215 items
+
+tests/components/firewalla_local/test_auth.py::test_load_qr_json_rejects_non_object_root PASSED [  0%]
+tests/components/firewalla_local/test_auth.py::test_parse_login_identity_rejects_invalid_json PASSED [  0%]
+tests/components/firewalla_local/test_auth.py::test_parse_login_identity_requires_access_token PASSED [  1%]
+tests/components/firewalla_local/test_auth.py::test_extract_groups_supports_wrapped_and_raw_lists PASSED [  1%]
+tests/components/firewalla_local/test_auth.py::test_extract_group_credentials_returns_credentials PASSED [  2%]
+tests/components/firewalla_local/test_auth.py::test_default_group_poll_attempts_extended_for_slower_cloud_link PASSED [  2%]
+tests/components/firewalla_local/test_auth.py::test_async_provision_firewalla_credentials_polls_until_group_visible PASSED [  3%]
+tests/components/firewalla_local/test_binary_sensor.py::test_watched_device_binary_sensor_exposes_state_and_attributes PASSED [  3%]
+tests/components/firewalla_local/test_binary_sensor.py::test_watched_device_binary_sensor_is_unavailable_when_host_missing PASSED [  4%]
+tests/components/firewalla_local/test_binary_sensor.py::test_watched_device_binary_sensor_uses_recent_activity_window PASSED [  4%]
+tests/components/firewalla_local/test_binary_sensor.py::test_watched_device_binary_sensor_name_updates_after_host_rename PASSED [  5%]
+tests/components/firewalla_local/test_binary_sensor.py::test_watched_device_binary_sensor_unique_ids_are_entry_scoped PASSED [  5%]
+tests/components/firewalla_local/test_boundaries.py::test_runtime_inventory_root_module_is_removed PASSED [  6%]
+tests/components/firewalla_local/test_boundaries.py::test_config_entry_writes_remain_in_coordinator_module PASSED [  6%]
+tests/components/firewalla_local/test_boundaries.py::test_platforms_do_not_call_protocol_mutations_directly PASSED [  6%]
+tests/components/firewalla_local/test_client.py::test_local_runtime_412_raises_not_ready_error PASSED [  7%]
+tests/components/firewalla_local/test_client.py::test_local_runtime_init_logs_at_info_for_pairing PASSED [  7%]
+tests/components/firewalla_local/test_client.py::test_get_pairing_runtime_init_payload_uses_phone_like_sequence PASSED [  8%]
+tests/components/firewalla_local/test_client.py::test_get_runtime_snapshot_normalizes_policy_rules PASSED [  8%]
+tests/components/firewalla_local/test_client.py::test_get_runtime_snapshot_normalizes_host_inventory PASSED [  9%]
+tests/components/firewalla_local/test_client.py::test_get_runtime_snapshot_prefers_customized_dns_hostname PASSED [  9%]
+tests/components/firewalla_local/test_client.py::test_get_runtime_snapshot_prefers_name_over_bname PASSED [ 10%]
+tests/components/firewalla_local/test_client.py::test_get_runtime_snapshot_derives_user_totals_and_group_links PASSED [ 10%]
+tests/components/firewalla_local/test_client.py::test_get_runtime_snapshot_prefers_internet_usage_totals_for_users PASSED [ 11%]
+tests/components/firewalla_local/test_client.py::test_get_runtime_snapshot_uses_affiliated_user_names_and_app_name_for_rules PASSED [ 11%]
+tests/components/firewalla_local/test_client.py::test_get_runtime_snapshot_omits_latest_speed_test_without_success PASSED [ 12%]
+tests/components/firewalla_local/test_client.py::test_async_wake_host_sends_host_targeted_command PASSED [ 12%]
+tests/components/firewalla_local/test_client.py::test_async_set_host_policy_sends_host_targeted_policy_write PASSED [ 13%]
+tests/components/firewalla_local/test_client.py::test_async_set_host_name_sends_host_targeted_write_and_accepts_null_ack PASSED [ 13%]
+tests/components/firewalla_local/test_client.py::test_async_set_host_dns_hostname_uses_hostdomain_write PASSED [ 13%]
+tests/components/firewalla_local/test_client.py::test_async_set_host_device_type_uses_feedback_write PASSED [ 14%]
+tests/components/firewalla_local/test_client.py::test_create_rule_sends_confirmed_persistent_payload PASSED [ 14%]
+tests/components/firewalla_local/test_client.py::test_delete_rule_sends_confirmed_delete_payload PASSED [ 15%]
+tests/components/firewalla_local/test_client.py::test_update_rule_sends_live_rule_payload_with_changed_state PASSED [ 15%]
+tests/components/firewalla_local/test_client.py::test_update_rule_control_only_resumes_existing_rule PASSED [ 16%]
+tests/components/firewalla_local/test_client.py::test_get_runtime_init_payload_retries_once_on_unauthorized PASSED [ 16%]
+tests/components/firewalla_local/test_client.py::test_get_runtime_init_payload_raises_auth_error_after_retry_401s PASSED [ 17%]
+tests/components/firewalla_local/test_client.py::test_get_usage_history_payload_sends_scoped_get_request PASSED [ 17%]
+tests/components/firewalla_local/test_client.py::test_get_wan_events_payload_accepts_list_response PASSED [ 18%]
+tests/components/firewalla_local/test_client.py::test_get_network_interface_payload_accepts_dict_response PASSED [ 18%]
+tests/components/firewalla_local/test_client.py::test_get_wan_events_payload_sends_paged_get_request PASSED [ 19%]
+tests/components/firewalla_local/test_client.py::test_get_network_interface_payload_sends_targeted_get_request PASSED [ 19%]
+tests/components/firewalla_local/test_config_flow.py::test_user_flow_prefills_resolved_default_host PASSED [ 20%]
+tests/components/firewalla_local/test_config_flow.py::test_user_flow_leaves_default_host_blank_when_resolution_fails PASSED [ 20%]
+tests/components/firewalla_local/test_config_flow.py::test_user_flow_creates_entry FAILED [ 20%]
+tests/components/firewalla_local/test_config_flow.py::test_duplicate_license_aborts FAILED [ 21%]
+tests/components/firewalla_local/test_config_flow.py::test_invalid_qr_shows_form_error FAILED [ 21%]
+tests/components/firewalla_local/test_config_flow.py::test_invalid_qr_shows_qr_error FAILED [ 22%]
+tests/components/firewalla_local/test_config_flow.py::test_user_flow_cannot_connect_shows_form_error FAILED [ 22%]
+tests/components/firewalla_local/test_config_flow.py::test_user_flow_cloud_link_timeout_shows_specific_error FAILED [ 23%]
+tests/components/firewalla_local/test_config_flow.py::test_user_flow_retries_local_runtime_activation_on_http_412 FAILED [ 23%]
+tests/components/firewalla_local/test_config_flow.py::test_user_flow_local_runtime_timeout_shows_specific_error FAILED [ 24%]
+tests/components/firewalla_local/test_config_flow.py::test_user_flow_logs_local_pairing_wait_details FAILED [ 24%]
+tests/components/firewalla_local/test_config_flow.py::test_user_flow_retries_local_runtime_disconnect_during_activation FAILED [ 25%]
+tests/components/firewalla_local/test_config_flow.py::test_user_flow_logs_local_disconnect_wait_details FAILED [ 25%]
+tests/components/firewalla_local/test_config_flow.py::test_user_flow_logs_pairing_failure_details FAILED [ 26%]
+tests/components/firewalla_local/test_config_flow.py::test_reauth_updates_existing_entry PASSED [ 26%]
+tests/components/firewalla_local/test_config_flow.py::test_reauth_invalid_host_shows_form_error PASSED [ 26%]
+tests/components/firewalla_local/test_config_flow.py::test_reauth_invalid_qr_shows_form_error PASSED [ 27%]
+tests/components/firewalla_local/test_config_flow.py::test_reauth_cannot_connect_shows_form_error PASSED [ 27%]
+tests/components/firewalla_local/test_config_flow.py::test_reauth_cloud_link_timeout_shows_specific_error PASSED [ 28%]
+tests/components/firewalla_local/test_config_flow.py::test_reauth_local_runtime_timeout_shows_specific_error PASSED [ 28%]
+tests/components/firewalla_local/test_config_flow.py::test_reauth_wrong_account_aborts PASSED [ 29%]
+tests/components/firewalla_local/test_config_flow.py::test_reconfigure_updates_existing_entry_host PASSED [ 29%]
+tests/components/firewalla_local/test_config_flow.py::test_reconfigure_invalid_host_shows_form_error PASSED [ 30%]
+tests/components/firewalla_local/test_config_flow.py::test_options_flow_handles_missing_runtime_data PASSED [ 30%]
+tests/components/firewalla_local/test_config_flow.py::test_options_flow_updates_selected_rule_ids PASSED [ 31%]
+tests/components/firewalla_local/test_config_flow.py::test_options_flow_updates_watched_devices PASSED [ 31%]
+tests/components/firewalla_local/test_config_flow.py::test_options_flow_updates_device_trackers PASSED [ 32%]
+tests/components/firewalla_local/test_config_flow.py::test_options_flow_preserves_missing_selected_watched_device PASSED [ 32%]
+tests/components/firewalla_local/test_config_flow.py::test_options_flow_preserves_missing_selected_device_tracker PASSED [ 33%]
+tests/components/firewalla_local/test_config_flow.py::test_options_flow_updates_watched_users PASSED [ 33%]
+tests/components/firewalla_local/test_config_flow.py::test_options_flow_preserves_missing_selected_watched_user PASSED [ 33%]
+tests/components/firewalla_local/test_config_flow.py::test_options_flow_system_settings_enforces_update_interval_bounds PASSED [ 34%]
+tests/components/firewalla_local/test_config_flow.py::test_options_flow_does_not_refresh_runtime_on_main_menu PASSED [ 34%]
+tests/components/firewalla_local/test_config_flow.py::test_options_flow_fallback_excludes_system_managed_rules PASSED [ 35%]
+tests/components/firewalla_local/test_config_flow.py::test_options_flow_fallback_matches_runtime_inventory_candidates PASSED [ 35%]
+tests/components/firewalla_local/test_config_flow.py::test_options_flow_allows_removing_missing_selected_rule PASSED [ 36%]
+tests/components/firewalla_local/test_config_flow.py::test_edit_rule_selection_can_return_to_main_menu_without_saving PASSED [ 36%]
+tests/components/firewalla_local/test_config_flow.py::test_system_settings_returns_to_main_menu_after_save PASSED [ 37%]
+tests/components/firewalla_local/test_config_flow.py::test_system_settings_can_return_to_main_menu_without_saving PASSED [ 37%]
+tests/components/firewalla_local/test_config_flow.py::test_options_flow_uses_manager_candidate_logic_for_rule_choices PASSED [ 38%]
+tests/components/firewalla_local/test_device_tracker.py::test_device_tracker_exposes_state_and_attributes PASSED [ 38%]
+tests/components/firewalla_local/test_device_tracker.py::test_device_tracker_is_unavailable_when_host_missing PASSED [ 39%]
+tests/components/firewalla_local/test_device_tracker.py::test_device_tracker_uses_recent_activity_window PASSED [ 39%]
+tests/components/firewalla_local/test_device_tracker.py::test_device_tracker_name_updates_after_host_rename PASSED [ 40%]
+tests/components/firewalla_local/test_device_tracker.py::test_device_tracker_unique_ids_are_entry_scoped PASSED [ 40%]
+tests/components/firewalla_local/test_diagnostics.py::test_get_config_entry_diagnostics_redacts_entry_data PASSED [ 40%]
+tests/components/firewalla_local/test_diagnostics.py::test_get_config_entry_diagnostics_handles_missing_snapshot PASSED [ 41%]
+tests/components/firewalla_local/test_init.py::test_setup_entry PASSED   [ 41%]
+tests/components/firewalla_local/test_init.py::test_setup_entry_reuses_cached_pairing_payload PASSED [ 42%]
+tests/components/firewalla_local/test_init.py::test_setup_entry_creates_runtime_sync_button PASSED [ 42%]
+tests/components/firewalla_local/test_init.py::test_runtime_sync_button_requests_refresh PASSED [ 43%]
+tests/components/firewalla_local/test_init.py::test_runtime_sync_button_logs_manual_refresh PASSED [ 43%]
+tests/components/firewalla_local/test_init.py::test_setup_uses_entry_scoped_update_interval_options PASSED [ 44%]
+tests/components/firewalla_local/test_init.py::test_options_update_changes_coordinator_interval_without_reload PASSED [ 44%]
+tests/components/firewalla_local/test_init.py::test_options_update_reloads_entry_when_watched_devices_change PASSED [ 45%]
+tests/components/firewalla_local/test_init.py::test_options_update_reloads_entry_when_device_trackers_change PASSED [ 45%]
+tests/components/firewalla_local/test_init.py::test_setup_multiple_entries_create_distinct_license_devices PASSED [ 46%]
+tests/components/firewalla_local/test_init.py::test_deselecting_device_tracker_removes_client_device_and_entity PASSED [ 46%]
+tests/components/firewalla_local/test_init.py::test_unloading_device_tracker_entry_preserves_registry_for_reload PASSED [ 46%]
+tests/components/firewalla_local/test_init.py::test_setup_multiple_entries_registers_domain_services_once PASSED [ 47%]
+tests/components/firewalla_local/test_init.py::test_setup_entry_normalizes_local_ip_to_host PASSED [ 47%]
+tests/components/firewalla_local/test_init.py::test_setup_entry_raises_auth_failed PASSED [ 48%]
+tests/components/firewalla_local/test_init.py::test_coordinator_logs_unavailability_once_and_recovery PASSED [ 48%]
+tests/components/firewalla_local/test_init.py::test_get_runtime_inventory_service_returns_markdown PASSED [ 49%]
+tests/components/firewalla_local/test_init.py::test_get_runtime_inventory_service_uses_single_loaded_entry PASSED [ 49%]
+tests/components/firewalla_local/test_init.py::test_get_runtime_inventory_service_accepts_entry_name PASSED [ 50%]
+tests/components/firewalla_local/test_init.py::test_setup_populates_raw_payload_for_live_rule_filtering PASSED [ 50%]
+tests/components/firewalla_local/test_init.py::test_get_runtime_inventory_service_rejects_unknown_entry PASSED [ 51%]
+tests/components/firewalla_local/test_init.py::test_get_runtime_inventory_service_requires_selector_with_multiple_entries PASSED [ 51%]
+tests/components/firewalla_local/test_integration_manager.py::test_handle_refresh_shapes_appliance_views PASSED [ 52%]
+tests/components/firewalla_local/test_integration_manager.py::test_handle_refresh_uses_raw_codename_when_release_map_is_missing PASSED [ 52%]
+tests/components/firewalla_local/test_integration_manager.py::test_build_device_info_uses_default_name_and_entry_unique_id PASSED [ 53%]
+tests/components/firewalla_local/test_integration_manager.py::test_latest_speed_test_is_none_without_successful_records PASSED [ 53%]
+tests/components/firewalla_local/test_integration_manager.py::test_get_speed_test_results_reuses_shaped_speed_test_path PASSED [ 53%]
+tests/components/firewalla_local/test_integration_manager.py::test_get_available_wans_includes_speed_test_uuid_fallback PASSED [ 54%]
+tests/components/firewalla_local/test_models.py::test_format_policy_rule_name_for_global_internet_rule PASSED [ 54%]
+tests/components/firewalla_local/test_models.py::test_format_policy_rule_name_uses_prettified_category_name PASSED [ 55%]
+tests/components/firewalla_local/test_models.py::test_format_policy_rule_name_hides_internal_network_uuid PASSED [ 55%]
+tests/components/firewalla_local/test_models.py::test_format_policy_rule_name_hides_internal_qos_uuid PASSED [ 56%]
+tests/components/firewalla_local/test_models.py::test_format_policy_rule_name_hides_app_category_target_slug PASSED [ 56%]
+tests/components/firewalla_local/test_models.py::test_format_policy_rule_name_prefers_custom_name PASSED [ 57%]
+tests/components/firewalla_local/test_models.py::test_supports_rule_switch_excludes_opaque_translation_list_categories PASSED [ 57%]
+tests/components/firewalla_local/test_models.py::test_supports_rule_switch_accepts_ip_rules PASSED [ 58%]
+tests/components/firewalla_local/test_models.py::test_supports_rule_switch_accepts_remote_port_rules PASSED [ 58%]
+tests/components/firewalla_local/test_models.py::test_supports_rule_switch_accepts_qos_rules PASSED [ 59%]
+tests/components/firewalla_local/test_models.py::test_supports_rule_switch_accepts_disturb_rules PASSED [ 59%]
+tests/components/firewalla_local/test_models.py::test_supports_rule_switch_accepts_network_rules_without_names PASSED [ 60%]
+tests/components/firewalla_local/test_models.py::test_supports_rule_switch_excludes_family_rules PASSED [ 60%]
+tests/components/firewalla_local/test_models.py::test_supports_rule_switch_excludes_dap_rules PASSED [ 60%]
+tests/components/firewalla_local/test_models.py::test_supports_rule_switch_accepts_port_forwarding_rules PASSED [ 61%]
+tests/components/firewalla_local/test_models.py::test_supports_rule_switch_excludes_unknown_non_null_purposes PASSED [ 61%]
+tests/components/firewalla_local/test_models.py::test_network_segment_view_host_count_tracks_normalized_hosts PASSED [ 62%]
+tests/components/firewalla_local/test_models.py::test_supports_rule_switch_excludes_firewall_rules PASSED [ 62%]
+tests/components/firewalla_local/test_rule_manager.py::test_get_switch_candidate_rule_ids_filters_system_managed_rules PASSED [ 63%]
+tests/components/firewalla_local/test_rule_manager.py::test_get_switch_candidate_choices_prefers_custom_rule_name PASSED [ 63%]
+tests/components/firewalla_local/test_rule_manager.py::test_load_selected_templates_refreshes_live_custom_name PASSED [ 64%]
+tests/components/firewalla_local/test_rule_manager.py::test_async_set_template_enabled_updates_snapshot_optimistically PASSED [ 64%]
+tests/components/firewalla_local/test_rule_manager.py::test_async_pause_and_resume_rule_update_snapshot_optimistically PASSED [ 65%]
+tests/components/firewalla_local/test_rule_manager.py::test_async_pause_rule_ignores_missing_targets PASSED [ 65%]
+tests/components/firewalla_local/test_runtime_inventory.py::test_build_runtime_inventory_report PASSED [ 66%]
+tests/components/firewalla_local/test_runtime_inventory.py::test_build_runtime_inventory_report_exposes_custom_name PASSED [ 66%]
+tests/components/firewalla_local/test_runtime_inventory.py::test_build_runtime_inventory_report_promotes_rule_metadata PASSED [ 66%]
+tests/components/firewalla_local/test_runtime_inventory.py::test_build_runtime_inventory_report_promotes_disturb_method PASSED [ 67%]
+tests/components/firewalla_local/test_sensor.py::test_sensor_setup_exposes_system_status_and_speed_test PASSED [ 67%]
+tests/components/firewalla_local/test_sensor.py::test_sensor_setup_handles_missing_speed_test_history PASSED [ 68%]
+tests/components/firewalla_local/test_sensor.py::test_sensor_setup_exposes_watched_user_usage_sensor PASSED [ 68%]
+tests/components/firewalla_local/test_sensor.py::test_watched_user_sensor_name_updates_after_user_rename PASSED [ 69%]
+tests/components/firewalla_local/test_sensor.py::test_sensor_setup_derives_watched_user_totals_and_group_associations PASSED [ 69%]
+tests/components/firewalla_local/test_sensor.py::test_system_status_device_counts_use_recent_activity_not_stale_only PASSED [ 70%]
+tests/components/firewalla_local/test_services.py::test_pause_rule_service_updates_matching_rule_optimistically PASSED [ 70%]
+tests/components/firewalla_local/test_services.py::test_pause_rule_service_refreshes_runtime_before_target_lookup PASSED [ 71%]
+tests/components/firewalla_local/test_services.py::test_pause_rule_service_rejects_invalid_duration PASSED [ 71%]
+tests/components/firewalla_local/test_services.py::test_pause_rule_service_supports_indefinite_pause PASSED [ 72%]
+tests/components/firewalla_local/test_services.py::test_pause_rule_service_supports_resume_at PASSED [ 72%]
+tests/components/firewalla_local/test_services.py::test_pause_rule_service_rejects_duration_and_resume_at PASSED [ 73%]
+tests/components/firewalla_local/test_services.py::test_get_loaded_entry_rejects_ambiguous_config_entry_name PASSED [ 73%]
+tests/components/firewalla_local/test_services.py::test_pause_rule_service_accepts_config_entry_name PASSED [ 73%]
+tests/components/firewalla_local/test_services.py::test_pause_rule_service_routes_to_requested_config_entry_id PASSED [ 74%]
+tests/components/firewalla_local/test_services.py::test_pause_rule_service_requires_selector_with_multiple_entries PASSED [ 74%]
+tests/components/firewalla_local/test_services.py::test_pause_rule_service_rejects_unknown_rule_target PASSED [ 75%]
+tests/components/firewalla_local/test_services.py::test_resume_rule_service_reenables_matching_rule PASSED [ 75%]
+tests/components/firewalla_local/test_services.py::test_run_internet_speed_test_service_returns_acknowledgement PASSED [ 76%]
+tests/components/firewalla_local/test_services.py::test_get_speed_test_results_service_defaults_to_latest_result PASSED [ 76%]
+tests/components/firewalla_local/test_services.py::test_get_speed_test_results_service_filters_one_wan_without_refresh PASSED [ 77%]
+tests/components/firewalla_local/test_services.py::test_run_internet_speed_test_service_requires_selector_for_multiple_wans PASSED [ 77%]
+tests/components/firewalla_local/test_services.py::test_wake_host_service_returns_acknowledgement_for_host_mac PASSED [ 78%]
+tests/components/firewalla_local/test_services.py::test_wake_host_service_resolves_unique_host_name PASSED [ 78%]
+tests/components/firewalla_local/test_services.py::test_wake_host_service_resolves_full_host_label PASSED [ 79%]
+tests/components/firewalla_local/test_services.py::test_wake_host_service_rejects_ambiguous_host_name PASSED [ 79%]
+tests/components/firewalla_local/test_services.py::test_wake_host_service_rejects_non_wol_host PASSED [ 80%]
+tests/components/firewalla_local/test_services.py::test_wake_host_service_raises_translated_runtime_error PASSED [ 80%]
+tests/components/firewalla_local/test_services.py::test_set_host_notify_when_next_online_returns_acknowledgement PASSED [ 80%]
+tests/components/firewalla_local/test_services.py::test_set_host_notify_when_next_offline_resolves_host_name PASSED [ 81%]
+tests/components/firewalla_local/test_services.py::test_set_host_name_returns_acknowledgement_for_host_mac PASSED [ 81%]
+tests/components/firewalla_local/test_services.py::test_set_host_name_resolves_unique_host_name PASSED [ 82%]
+tests/components/firewalla_local/test_services.py::test_set_host_dns_hostname_returns_acknowledgement_for_host_mac PASSED [ 82%]
+tests/components/firewalla_local/test_services.py::test_set_host_device_type_returns_acknowledgement_for_host_mac PASSED [ 83%]
+tests/components/firewalla_local/test_services.py::test_get_host_name_mapping_returns_host_identity_records PASSED [ 83%]
+tests/components/firewalla_local/test_services.py::test_set_host_dhcp_reservation_returns_acknowledgement_for_static_mode PASSED [ 84%]
+tests/components/firewalla_local/test_services.py::test_set_host_dhcp_reservation_resolves_names_for_dynamic_mode PASSED [ 84%]
+tests/components/firewalla_local/test_services.py::test_set_host_dhcp_reservation_requires_ipv4_for_static_mode PASSED [ 85%]
+tests/components/firewalla_local/test_services.py::test_set_host_dhcp_reservation_infers_network_from_ipv4 PASSED [ 85%]
+tests/components/firewalla_local/test_services.py::test_set_host_dhcp_reservation_rejects_ipv4_outside_network_range PASSED [ 86%]
+tests/components/firewalla_local/test_services.py::test_set_host_dhcp_reservation_rejects_duplicate_ipv4_on_same_network PASSED [ 86%]
+tests/components/firewalla_local/test_services.py::test_get_time_usage_report_service_resolves_device_label_and_serializes_data PASSED [ 86%]
+tests/components/firewalla_local/test_services.py::test_get_time_usage_report_service_detail_intervals_keeps_intervals PASSED [ 87%]
+tests/components/firewalla_local/test_services.py::test_get_time_usage_report_service_resolves_user_name_to_tag_scope PASSED [ 87%]
+tests/components/firewalla_local/test_services.py::test_get_time_usage_report_service_preserves_explicit_empty_app_list PASSED [ 88%]
+tests/components/firewalla_local/test_services.py::test_get_time_usage_report_service_honors_requested_sections PASSED [ 88%]
+tests/components/firewalla_local/test_services.py::test_get_time_usage_report_service_non_empty_app_filter_adds_apps_section PASSED [ 89%]
+tests/components/firewalla_local/test_services.py::test_get_time_usage_report_service_ranks_apps_and_filters_zero_only_rows PASSED [ 89%]
+tests/components/firewalla_local/test_services.py::test_get_wan_data_usage_service_returns_current_month_summary_by_default PASSED [ 90%]
+tests/components/firewalla_local/test_services.py::test_get_wan_data_usage_service_adds_daily_detail_to_current_month PASSED [ 90%]
+tests/components/firewalla_local/test_services.py::test_get_wan_data_usage_service_returns_history_months_only PASSED [ 91%]
+tests/components/firewalla_local/test_services.py::test_get_wan_data_usage_service_reports_unavailable_history_include PASSED [ 91%]
+tests/components/firewalla_local/test_services.py::test_get_network_segment_report_service_returns_configuration_report PASSED [ 92%]
+tests/components/firewalla_local/test_services.py::test_get_network_segment_report_service_requires_network_selector PASSED [ 92%]
+tests/components/firewalla_local/test_services.py::test_get_network_segment_usage_service_returns_summary_report PASSED [ 93%]
+tests/components/firewalla_local/test_services.py::test_get_network_segment_usage_service_derives_activity_from_flows PASSED [ 93%]
+tests/components/firewalla_local/test_services.py::test_get_network_segment_usage_service_returns_series_when_requested PASSED [ 93%]
+tests/components/firewalla_local/test_services.py::test_get_network_segment_usage_service_requires_window PASSED [ 94%]
+tests/components/firewalla_local/test_services.py::test_get_network_segment_usage_service_requires_network_selector PASSED [ 94%]
+tests/components/firewalla_local/test_services.py::test_get_wan_data_usage_service_returns_history_days_in_local_time PASSED [ 95%]
+tests/components/firewalla_local/test_services.py::test_get_wan_data_usage_service_returns_current_and_history_weeks PASSED [ 95%]
+tests/components/firewalla_local/test_services.py::test_get_wan_events_service_returns_normalized_timeline PASSED [ 96%]
+tests/components/firewalla_local/test_switch.py::test_selected_rule_switch_turns_rule_off_and_on PASSED [ 96%]
+tests/components/firewalla_local/test_switch.py::test_selected_rule_switch_uses_live_custom_name PASSED [ 97%]
+tests/components/firewalla_local/test_switch.py::test_selected_rule_switch_name_updates_after_rule_rename PASSED [ 97%]
+tests/components/firewalla_local/test_switch.py::test_selected_rule_switch_is_unavailable_when_rule_is_missing PASSED [ 98%]
+tests/components/firewalla_local/test_switch.py::test_selected_rule_switch_does_not_guess_replacement_rule PASSED [ 98%]
+tests/components/firewalla_local/test_switch.py::test_selected_rule_switch_exposes_pause_and_notes_attributes PASSED [ 99%]
+tests/components/firewalla_local/test_switch.py::test_selected_rule_switch_exposes_schedule_and_time_limit_attributes PASSED [ 99%]
+tests/components/firewalla_local/test_switch.py::test_deselecting_all_rules_removes_switch_entities PASSED [100%]
+
+=================================== FAILURES ===================================
+_________________________ test_user_flow_creates_entry _________________________
+
+hass = <HomeAssistant RUNNING>
+
+    async def test_user_flow_creates_entry(hass) -> None:
+        """Test the user flow creates an entry."""
+>       result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+
+tests/components/firewalla_local/test_config_flow.py:157: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1511: in async_init
+    flow, result = await self._async_init(flow_id, handler, context, data)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1574: in _async_init
+    result = await self._async_handle_step(flow, flow.init_step, data)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/data_entry_flow.py:483: in _async_handle_step
+    result: _FlowResultT = await getattr(flow, method)(user_input)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:433: in async_step_user
+    self._suggested_host = await self.hass.async_add_executor_job(
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:86: in run
+    result = ctx.run(self.task)
+             ^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:73: in run
+    return fn(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:168: in _resolve_default_pairing_host
+    addrinfo = socket.getaddrinfo(
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:227: in getaddrinfo_patched
+    _validate_host(host)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+host = 'fire.walla'
+
+    def _validate_host(host):
+        if host in ("localhost", "127.0.0.1", "::1", None, "", "0.0.0.0", "::"):
+            return
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+>           raise RuntimeError("DNS resolution disabled in tests") from None
+E           RuntimeError: DNS resolution disabled in tests
+
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:224: RuntimeError
+---------------------------- Captured stderr setup -----------------------------
+DEBUG:asyncio:Using selector: EpollSelector
+DEBUG:homeassistant.helpers.restore_state:Not creating cache - no saved states found
+------------------------------ Captured log setup ------------------------------
+DEBUG    asyncio:selector_events.py:64 Using selector: EpollSelector
+DEBUG    homeassistant.helpers.restore_state:restore_state.py:156 Not creating cache - no saved states found
+----------------------------- Captured stderr call -----------------------------
+INFO:homeassistant.loader:Loaded firewalla_local from custom_components.firewalla_local
+WARNING:homeassistant.loader:We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG:homeassistant.loader:Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+------------------------------ Captured log call -------------------------------
+INFO     homeassistant.loader:loader.py:785 Loaded firewalla_local from custom_components.firewalla_local
+WARNING  homeassistant.loader:loader.py:700 We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG    homeassistant.loader:loader.py:1202 Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+--------------------------- Captured stderr teardown ---------------------------
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_stop[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_close[L]>
+DEBUG:asyncio:Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+---------------------------- Captured log teardown -----------------------------
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_stop[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_close[L]>
+DEBUG    asyncio:base_events.py:742 Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+________________________ test_duplicate_license_aborts _________________________
+
+hass = <HomeAssistant RUNNING>
+
+    async def test_duplicate_license_aborts(hass) -> None:
+        """Test duplicate Firewalla licenses are rejected."""
+        existing_entry = MockConfigEntry(
+            domain=DOMAIN,
+            unique_id="license-123",
+            title="Firewalla (192.168.200.1)",
+            data={
+                CONF_LICENSE: "license-123",
+                CONF_HOST: "192.168.200.1",
+                CONF_GID: "gid-123",
+                CONF_EID: "eid-123",
+                CONF_AID: "aid-123",
+                CONF_SYMMETRIC_KEY: "symmetric-key",
+            },
+        )
+        existing_entry.add_to_hass(hass)
+    
+>       result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+
+tests/components/firewalla_local/test_config_flow.py:220: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1511: in async_init
+    flow, result = await self._async_init(flow_id, handler, context, data)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1574: in _async_init
+    result = await self._async_handle_step(flow, flow.init_step, data)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/data_entry_flow.py:483: in _async_handle_step
+    result: _FlowResultT = await getattr(flow, method)(user_input)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:433: in async_step_user
+    self._suggested_host = await self.hass.async_add_executor_job(
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:86: in run
+    result = ctx.run(self.task)
+             ^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:73: in run
+    return fn(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:168: in _resolve_default_pairing_host
+    addrinfo = socket.getaddrinfo(
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:227: in getaddrinfo_patched
+    _validate_host(host)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+host = 'fire.walla'
+
+    def _validate_host(host):
+        if host in ("localhost", "127.0.0.1", "::1", None, "", "0.0.0.0", "::"):
+            return
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+>           raise RuntimeError("DNS resolution disabled in tests") from None
+E           RuntimeError: DNS resolution disabled in tests
+
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:224: RuntimeError
+---------------------------- Captured stderr setup -----------------------------
+DEBUG:asyncio:Using selector: EpollSelector
+DEBUG:homeassistant.helpers.restore_state:Not creating cache - no saved states found
+------------------------------ Captured log setup ------------------------------
+DEBUG    asyncio:selector_events.py:64 Using selector: EpollSelector
+DEBUG    homeassistant.helpers.restore_state:restore_state.py:156 Not creating cache - no saved states found
+----------------------------- Captured stderr call -----------------------------
+INFO:homeassistant.loader:Loaded firewalla_local from custom_components.firewalla_local
+WARNING:homeassistant.loader:We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG:homeassistant.loader:Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+------------------------------ Captured log call -------------------------------
+INFO     homeassistant.loader:loader.py:785 Loaded firewalla_local from custom_components.firewalla_local
+WARNING  homeassistant.loader:loader.py:700 We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG    homeassistant.loader:loader.py:1202 Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+--------------------------- Captured stderr teardown ---------------------------
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_stop[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_close[L]>
+DEBUG:asyncio:Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+---------------------------- Captured log teardown -----------------------------
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_stop[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_close[L]>
+DEBUG    asyncio:base_events.py:742 Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+_______________________ test_invalid_qr_shows_form_error _______________________
+
+hass = <HomeAssistant RUNNING>
+
+    async def test_invalid_qr_shows_form_error(hass) -> None:
+        """Test an invalid host is rejected before provisioning starts."""
+>       result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+
+tests/components/firewalla_local/test_config_flow.py:239: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1511: in async_init
+    flow, result = await self._async_init(flow_id, handler, context, data)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1574: in _async_init
+    result = await self._async_handle_step(flow, flow.init_step, data)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/data_entry_flow.py:483: in _async_handle_step
+    result: _FlowResultT = await getattr(flow, method)(user_input)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:433: in async_step_user
+    self._suggested_host = await self.hass.async_add_executor_job(
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:86: in run
+    result = ctx.run(self.task)
+             ^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:73: in run
+    return fn(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:168: in _resolve_default_pairing_host
+    addrinfo = socket.getaddrinfo(
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:227: in getaddrinfo_patched
+    _validate_host(host)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+host = 'fire.walla'
+
+    def _validate_host(host):
+        if host in ("localhost", "127.0.0.1", "::1", None, "", "0.0.0.0", "::"):
+            return
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+>           raise RuntimeError("DNS resolution disabled in tests") from None
+E           RuntimeError: DNS resolution disabled in tests
+
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:224: RuntimeError
+---------------------------- Captured stderr setup -----------------------------
+DEBUG:asyncio:Using selector: EpollSelector
+DEBUG:homeassistant.helpers.restore_state:Not creating cache - no saved states found
+------------------------------ Captured log setup ------------------------------
+DEBUG    asyncio:selector_events.py:64 Using selector: EpollSelector
+DEBUG    homeassistant.helpers.restore_state:restore_state.py:156 Not creating cache - no saved states found
+----------------------------- Captured stderr call -----------------------------
+INFO:homeassistant.loader:Loaded firewalla_local from custom_components.firewalla_local
+WARNING:homeassistant.loader:We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG:homeassistant.loader:Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+------------------------------ Captured log call -------------------------------
+INFO     homeassistant.loader:loader.py:785 Loaded firewalla_local from custom_components.firewalla_local
+WARNING  homeassistant.loader:loader.py:700 We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG    homeassistant.loader:loader.py:1202 Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+--------------------------- Captured stderr teardown ---------------------------
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_stop[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_close[L]>
+DEBUG:asyncio:Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+---------------------------- Captured log teardown -----------------------------
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_stop[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_close[L]>
+DEBUG    asyncio:base_events.py:742 Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+________________________ test_invalid_qr_shows_qr_error ________________________
+
+hass = <HomeAssistant RUNNING>
+
+    async def test_invalid_qr_shows_qr_error(hass) -> None:
+        """Test malformed QR JSON returns the QR validation error."""
+>       result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+
+tests/components/firewalla_local/test_config_flow.py:258: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1511: in async_init
+    flow, result = await self._async_init(flow_id, handler, context, data)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1574: in _async_init
+    result = await self._async_handle_step(flow, flow.init_step, data)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/data_entry_flow.py:483: in _async_handle_step
+    result: _FlowResultT = await getattr(flow, method)(user_input)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:433: in async_step_user
+    self._suggested_host = await self.hass.async_add_executor_job(
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:86: in run
+    result = ctx.run(self.task)
+             ^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:73: in run
+    return fn(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:168: in _resolve_default_pairing_host
+    addrinfo = socket.getaddrinfo(
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:227: in getaddrinfo_patched
+    _validate_host(host)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+host = 'fire.walla'
+
+    def _validate_host(host):
+        if host in ("localhost", "127.0.0.1", "::1", None, "", "0.0.0.0", "::"):
+            return
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+>           raise RuntimeError("DNS resolution disabled in tests") from None
+E           RuntimeError: DNS resolution disabled in tests
+
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:224: RuntimeError
+---------------------------- Captured stderr setup -----------------------------
+DEBUG:asyncio:Using selector: EpollSelector
+DEBUG:homeassistant.helpers.restore_state:Not creating cache - no saved states found
+------------------------------ Captured log setup ------------------------------
+DEBUG    asyncio:selector_events.py:64 Using selector: EpollSelector
+DEBUG    homeassistant.helpers.restore_state:restore_state.py:156 Not creating cache - no saved states found
+----------------------------- Captured stderr call -----------------------------
+INFO:homeassistant.loader:Loaded firewalla_local from custom_components.firewalla_local
+WARNING:homeassistant.loader:We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG:homeassistant.loader:Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+------------------------------ Captured log call -------------------------------
+INFO     homeassistant.loader:loader.py:785 Loaded firewalla_local from custom_components.firewalla_local
+WARNING  homeassistant.loader:loader.py:700 We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG    homeassistant.loader:loader.py:1202 Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+--------------------------- Captured stderr teardown ---------------------------
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_stop[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_close[L]>
+DEBUG:asyncio:Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+---------------------------- Captured log teardown -----------------------------
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_stop[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_close[L]>
+DEBUG    asyncio:base_events.py:742 Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+________________ test_user_flow_cannot_connect_shows_form_error ________________
+
+hass = <HomeAssistant RUNNING>
+
+    async def test_user_flow_cannot_connect_shows_form_error(hass) -> None:
+        """Test a pairing connectivity failure returns the cannot_connect error."""
+>       result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+
+tests/components/firewalla_local/test_config_flow.py:277: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1511: in async_init
+    flow, result = await self._async_init(flow_id, handler, context, data)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1574: in _async_init
+    result = await self._async_handle_step(flow, flow.init_step, data)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/data_entry_flow.py:483: in _async_handle_step
+    result: _FlowResultT = await getattr(flow, method)(user_input)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:433: in async_step_user
+    self._suggested_host = await self.hass.async_add_executor_job(
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:86: in run
+    result = ctx.run(self.task)
+             ^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:73: in run
+    return fn(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:168: in _resolve_default_pairing_host
+    addrinfo = socket.getaddrinfo(
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:227: in getaddrinfo_patched
+    _validate_host(host)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+host = 'fire.walla'
+
+    def _validate_host(host):
+        if host in ("localhost", "127.0.0.1", "::1", None, "", "0.0.0.0", "::"):
+            return
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+>           raise RuntimeError("DNS resolution disabled in tests") from None
+E           RuntimeError: DNS resolution disabled in tests
+
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:224: RuntimeError
+---------------------------- Captured stderr setup -----------------------------
+DEBUG:asyncio:Using selector: EpollSelector
+DEBUG:homeassistant.helpers.restore_state:Not creating cache - no saved states found
+------------------------------ Captured log setup ------------------------------
+DEBUG    asyncio:selector_events.py:64 Using selector: EpollSelector
+DEBUG    homeassistant.helpers.restore_state:restore_state.py:156 Not creating cache - no saved states found
+----------------------------- Captured stderr call -----------------------------
+INFO:homeassistant.loader:Loaded firewalla_local from custom_components.firewalla_local
+WARNING:homeassistant.loader:We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG:homeassistant.loader:Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+------------------------------ Captured log call -------------------------------
+INFO     homeassistant.loader:loader.py:785 Loaded firewalla_local from custom_components.firewalla_local
+WARNING  homeassistant.loader:loader.py:700 We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG    homeassistant.loader:loader.py:1202 Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+--------------------------- Captured stderr teardown ---------------------------
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_stop[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_close[L]>
+DEBUG:asyncio:Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+---------------------------- Captured log teardown -----------------------------
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_stop[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_close[L]>
+DEBUG    asyncio:base_events.py:742 Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+____________ test_user_flow_cloud_link_timeout_shows_specific_error ____________
+
+hass = <HomeAssistant RUNNING>
+
+    async def test_user_flow_cloud_link_timeout_shows_specific_error(hass) -> None:
+        """Test a cloud pairing timeout returns a specific config flow error."""
+>       result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+
+tests/components/firewalla_local/test_config_flow.py:306: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1511: in async_init
+    flow, result = await self._async_init(flow_id, handler, context, data)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1574: in _async_init
+    result = await self._async_handle_step(flow, flow.init_step, data)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/data_entry_flow.py:483: in _async_handle_step
+    result: _FlowResultT = await getattr(flow, method)(user_input)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:433: in async_step_user
+    self._suggested_host = await self.hass.async_add_executor_job(
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:86: in run
+    result = ctx.run(self.task)
+             ^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:73: in run
+    return fn(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:168: in _resolve_default_pairing_host
+    addrinfo = socket.getaddrinfo(
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:227: in getaddrinfo_patched
+    _validate_host(host)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+host = 'fire.walla'
+
+    def _validate_host(host):
+        if host in ("localhost", "127.0.0.1", "::1", None, "", "0.0.0.0", "::"):
+            return
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+>           raise RuntimeError("DNS resolution disabled in tests") from None
+E           RuntimeError: DNS resolution disabled in tests
+
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:224: RuntimeError
+---------------------------- Captured stderr setup -----------------------------
+DEBUG:asyncio:Using selector: EpollSelector
+DEBUG:homeassistant.helpers.restore_state:Not creating cache - no saved states found
+------------------------------ Captured log setup ------------------------------
+DEBUG    asyncio:selector_events.py:64 Using selector: EpollSelector
+DEBUG    homeassistant.helpers.restore_state:restore_state.py:156 Not creating cache - no saved states found
+----------------------------- Captured stderr call -----------------------------
+INFO:homeassistant.loader:Loaded firewalla_local from custom_components.firewalla_local
+WARNING:homeassistant.loader:We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG:homeassistant.loader:Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+------------------------------ Captured log call -------------------------------
+INFO     homeassistant.loader:loader.py:785 Loaded firewalla_local from custom_components.firewalla_local
+WARNING  homeassistant.loader:loader.py:700 We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG    homeassistant.loader:loader.py:1202 Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+--------------------------- Captured stderr teardown ---------------------------
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_stop[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_close[L]>
+DEBUG:asyncio:Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+---------------------------- Captured log teardown -----------------------------
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_stop[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_close[L]>
+DEBUG    asyncio:base_events.py:742 Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+_________ test_user_flow_retries_local_runtime_activation_on_http_412 __________
+
+hass = <HomeAssistant RUNNING>
+
+    async def test_user_flow_retries_local_runtime_activation_on_http_412(hass) -> None:
+        """Test pairing retries temporary local runtime activation delays."""
+>       result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+
+tests/components/firewalla_local/test_config_flow.py:340: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1511: in async_init
+    flow, result = await self._async_init(flow_id, handler, context, data)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1574: in _async_init
+    result = await self._async_handle_step(flow, flow.init_step, data)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/data_entry_flow.py:483: in _async_handle_step
+    result: _FlowResultT = await getattr(flow, method)(user_input)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:433: in async_step_user
+    self._suggested_host = await self.hass.async_add_executor_job(
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:86: in run
+    result = ctx.run(self.task)
+             ^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:73: in run
+    return fn(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:168: in _resolve_default_pairing_host
+    addrinfo = socket.getaddrinfo(
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:227: in getaddrinfo_patched
+    _validate_host(host)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+host = 'fire.walla'
+
+    def _validate_host(host):
+        if host in ("localhost", "127.0.0.1", "::1", None, "", "0.0.0.0", "::"):
+            return
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+>           raise RuntimeError("DNS resolution disabled in tests") from None
+E           RuntimeError: DNS resolution disabled in tests
+
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:224: RuntimeError
+---------------------------- Captured stderr setup -----------------------------
+DEBUG:asyncio:Using selector: EpollSelector
+DEBUG:homeassistant.helpers.restore_state:Not creating cache - no saved states found
+------------------------------ Captured log setup ------------------------------
+DEBUG    asyncio:selector_events.py:64 Using selector: EpollSelector
+DEBUG    homeassistant.helpers.restore_state:restore_state.py:156 Not creating cache - no saved states found
+----------------------------- Captured stderr call -----------------------------
+INFO:homeassistant.loader:Loaded firewalla_local from custom_components.firewalla_local
+WARNING:homeassistant.loader:We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG:homeassistant.loader:Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+------------------------------ Captured log call -------------------------------
+INFO     homeassistant.loader:loader.py:785 Loaded firewalla_local from custom_components.firewalla_local
+WARNING  homeassistant.loader:loader.py:700 We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG    homeassistant.loader:loader.py:1202 Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+--------------------------- Captured stderr teardown ---------------------------
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_stop[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_close[L]>
+DEBUG:asyncio:Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+---------------------------- Captured log teardown -----------------------------
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_stop[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_close[L]>
+DEBUG    asyncio:base_events.py:742 Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+__________ test_user_flow_local_runtime_timeout_shows_specific_error ___________
+
+hass = <HomeAssistant RUNNING>
+
+    async def test_user_flow_local_runtime_timeout_shows_specific_error(hass) -> None:
+        """Test local pairing activation timeout returns a specific config error."""
+>       result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+
+tests/components/firewalla_local/test_config_flow.py:397: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1511: in async_init
+    flow, result = await self._async_init(flow_id, handler, context, data)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1574: in _async_init
+    result = await self._async_handle_step(flow, flow.init_step, data)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/data_entry_flow.py:483: in _async_handle_step
+    result: _FlowResultT = await getattr(flow, method)(user_input)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:433: in async_step_user
+    self._suggested_host = await self.hass.async_add_executor_job(
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:86: in run
+    result = ctx.run(self.task)
+             ^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:73: in run
+    return fn(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:168: in _resolve_default_pairing_host
+    addrinfo = socket.getaddrinfo(
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:227: in getaddrinfo_patched
+    _validate_host(host)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+host = 'fire.walla'
+
+    def _validate_host(host):
+        if host in ("localhost", "127.0.0.1", "::1", None, "", "0.0.0.0", "::"):
+            return
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+>           raise RuntimeError("DNS resolution disabled in tests") from None
+E           RuntimeError: DNS resolution disabled in tests
+
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:224: RuntimeError
+---------------------------- Captured stderr setup -----------------------------
+DEBUG:asyncio:Using selector: EpollSelector
+DEBUG:homeassistant.helpers.restore_state:Not creating cache - no saved states found
+------------------------------ Captured log setup ------------------------------
+DEBUG    asyncio:selector_events.py:64 Using selector: EpollSelector
+DEBUG    homeassistant.helpers.restore_state:restore_state.py:156 Not creating cache - no saved states found
+----------------------------- Captured stderr call -----------------------------
+INFO:homeassistant.loader:Loaded firewalla_local from custom_components.firewalla_local
+WARNING:homeassistant.loader:We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG:homeassistant.loader:Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+------------------------------ Captured log call -------------------------------
+INFO     homeassistant.loader:loader.py:785 Loaded firewalla_local from custom_components.firewalla_local
+WARNING  homeassistant.loader:loader.py:700 We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG    homeassistant.loader:loader.py:1202 Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+--------------------------- Captured stderr teardown ---------------------------
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_stop[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_close[L]>
+DEBUG:asyncio:Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+---------------------------- Captured log teardown -----------------------------
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_stop[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_close[L]>
+DEBUG    asyncio:base_events.py:742 Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+________________ test_user_flow_logs_local_pairing_wait_details ________________
+
+hass = <HomeAssistant RUNNING>
+caplog = <_pytest.logging.LogCaptureFixture object at 0x7be06c275810>
+
+    async def test_user_flow_logs_local_pairing_wait_details(hass, caplog) -> None:
+        """Test local pairing waits emit info-level timing logs."""
+>       result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+
+tests/components/firewalla_local/test_config_flow.py:443: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1511: in async_init
+    flow, result = await self._async_init(flow_id, handler, context, data)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1574: in _async_init
+    result = await self._async_handle_step(flow, flow.init_step, data)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/data_entry_flow.py:483: in _async_handle_step
+    result: _FlowResultT = await getattr(flow, method)(user_input)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:433: in async_step_user
+    self._suggested_host = await self.hass.async_add_executor_job(
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:86: in run
+    result = ctx.run(self.task)
+             ^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:73: in run
+    return fn(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:168: in _resolve_default_pairing_host
+    addrinfo = socket.getaddrinfo(
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:227: in getaddrinfo_patched
+    _validate_host(host)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+host = 'fire.walla'
+
+    def _validate_host(host):
+        if host in ("localhost", "127.0.0.1", "::1", None, "", "0.0.0.0", "::"):
+            return
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+>           raise RuntimeError("DNS resolution disabled in tests") from None
+E           RuntimeError: DNS resolution disabled in tests
+
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:224: RuntimeError
+---------------------------- Captured stderr setup -----------------------------
+DEBUG:asyncio:Using selector: EpollSelector
+DEBUG:homeassistant.helpers.restore_state:Not creating cache - no saved states found
+------------------------------ Captured log setup ------------------------------
+DEBUG    asyncio:selector_events.py:64 Using selector: EpollSelector
+DEBUG    homeassistant.helpers.restore_state:restore_state.py:156 Not creating cache - no saved states found
+----------------------------- Captured stderr call -----------------------------
+INFO:homeassistant.loader:Loaded firewalla_local from custom_components.firewalla_local
+WARNING:homeassistant.loader:We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG:homeassistant.loader:Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+------------------------------ Captured log call -------------------------------
+INFO     homeassistant.loader:loader.py:785 Loaded firewalla_local from custom_components.firewalla_local
+WARNING  homeassistant.loader:loader.py:700 We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG    homeassistant.loader:loader.py:1202 Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+--------------------------- Captured stderr teardown ---------------------------
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_stop[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_close[L]>
+DEBUG:asyncio:Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+---------------------------- Captured log teardown -----------------------------
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_stop[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_close[L]>
+DEBUG    asyncio:base_events.py:742 Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+______ test_user_flow_retries_local_runtime_disconnect_during_activation _______
+
+hass = <HomeAssistant RUNNING>
+
+    async def test_user_flow_retries_local_runtime_disconnect_during_activation(
+        hass,
+    ) -> None:
+        """Test pairing retries a transient local disconnect during activation."""
+>       result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+
+tests/components/firewalla_local/test_config_flow.py:519: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1511: in async_init
+    flow, result = await self._async_init(flow_id, handler, context, data)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1574: in _async_init
+    result = await self._async_handle_step(flow, flow.init_step, data)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/data_entry_flow.py:483: in _async_handle_step
+    result: _FlowResultT = await getattr(flow, method)(user_input)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:433: in async_step_user
+    self._suggested_host = await self.hass.async_add_executor_job(
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:86: in run
+    result = ctx.run(self.task)
+             ^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:73: in run
+    return fn(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:168: in _resolve_default_pairing_host
+    addrinfo = socket.getaddrinfo(
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:227: in getaddrinfo_patched
+    _validate_host(host)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+host = 'fire.walla'
+
+    def _validate_host(host):
+        if host in ("localhost", "127.0.0.1", "::1", None, "", "0.0.0.0", "::"):
+            return
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+>           raise RuntimeError("DNS resolution disabled in tests") from None
+E           RuntimeError: DNS resolution disabled in tests
+
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:224: RuntimeError
+---------------------------- Captured stderr setup -----------------------------
+DEBUG:asyncio:Using selector: EpollSelector
+DEBUG:homeassistant.helpers.restore_state:Not creating cache - no saved states found
+------------------------------ Captured log setup ------------------------------
+DEBUG    asyncio:selector_events.py:64 Using selector: EpollSelector
+DEBUG    homeassistant.helpers.restore_state:restore_state.py:156 Not creating cache - no saved states found
+----------------------------- Captured stderr call -----------------------------
+INFO:homeassistant.loader:Loaded firewalla_local from custom_components.firewalla_local
+WARNING:homeassistant.loader:We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG:homeassistant.loader:Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+------------------------------ Captured log call -------------------------------
+INFO     homeassistant.loader:loader.py:785 Loaded firewalla_local from custom_components.firewalla_local
+WARNING  homeassistant.loader:loader.py:700 We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG    homeassistant.loader:loader.py:1202 Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+--------------------------- Captured stderr teardown ---------------------------
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_stop[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_close[L]>
+DEBUG:asyncio:Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+---------------------------- Captured log teardown -----------------------------
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_stop[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_close[L]>
+DEBUG    asyncio:base_events.py:742 Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+______________ test_user_flow_logs_local_disconnect_wait_details _______________
+
+hass = <HomeAssistant RUNNING>
+caplog = <_pytest.logging.LogCaptureFixture object at 0x7be069c3f390>
+
+    async def test_user_flow_logs_local_disconnect_wait_details(hass, caplog) -> None:
+        """Test local activation disconnects emit retriable timing logs."""
+>       result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+
+tests/components/firewalla_local/test_config_flow.py:576: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1511: in async_init
+    flow, result = await self._async_init(flow_id, handler, context, data)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1574: in _async_init
+    result = await self._async_handle_step(flow, flow.init_step, data)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/data_entry_flow.py:483: in _async_handle_step
+    result: _FlowResultT = await getattr(flow, method)(user_input)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:433: in async_step_user
+    self._suggested_host = await self.hass.async_add_executor_job(
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:86: in run
+    result = ctx.run(self.task)
+             ^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:73: in run
+    return fn(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:168: in _resolve_default_pairing_host
+    addrinfo = socket.getaddrinfo(
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:227: in getaddrinfo_patched
+    _validate_host(host)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+host = 'fire.walla'
+
+    def _validate_host(host):
+        if host in ("localhost", "127.0.0.1", "::1", None, "", "0.0.0.0", "::"):
+            return
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+>           raise RuntimeError("DNS resolution disabled in tests") from None
+E           RuntimeError: DNS resolution disabled in tests
+
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:224: RuntimeError
+---------------------------- Captured stderr setup -----------------------------
+DEBUG:asyncio:Using selector: EpollSelector
+DEBUG:homeassistant.helpers.restore_state:Not creating cache - no saved states found
+------------------------------ Captured log setup ------------------------------
+DEBUG    asyncio:selector_events.py:64 Using selector: EpollSelector
+DEBUG    homeassistant.helpers.restore_state:restore_state.py:156 Not creating cache - no saved states found
+----------------------------- Captured stderr call -----------------------------
+INFO:homeassistant.loader:Loaded firewalla_local from custom_components.firewalla_local
+WARNING:homeassistant.loader:We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG:homeassistant.loader:Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+------------------------------ Captured log call -------------------------------
+INFO     homeassistant.loader:loader.py:785 Loaded firewalla_local from custom_components.firewalla_local
+WARNING  homeassistant.loader:loader.py:700 We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG    homeassistant.loader:loader.py:1202 Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+--------------------------- Captured stderr teardown ---------------------------
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_stop[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_close[L]>
+DEBUG:asyncio:Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+---------------------------- Captured log teardown -----------------------------
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_stop[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_close[L]>
+DEBUG    asyncio:base_events.py:742 Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+_________________ test_user_flow_logs_pairing_failure_details __________________
+
+hass = <HomeAssistant RUNNING>
+caplog = <_pytest.logging.LogCaptureFixture object at 0x7be069da8fc0>
+
+    async def test_user_flow_logs_pairing_failure_details(hass, caplog) -> None:
+        """Test pairing failures emit useful logs for support triage."""
+>       result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+
+tests/components/firewalla_local/test_config_flow.py:646: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1511: in async_init
+    flow, result = await self._async_init(flow_id, handler, context, data)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/config_entries.py:1574: in _async_init
+    result = await self._async_handle_step(flow, flow.init_step, data)
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/homeassistant/data_entry_flow.py:483: in _async_handle_step
+    result: _FlowResultT = await getattr(flow, method)(user_input)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:433: in async_step_user
+    self._suggested_host = await self.hass.async_add_executor_job(
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:86: in run
+    result = ctx.run(self.task)
+             ^^^^^^^^^^^^^^^^^^
+/home/vscode/.local/share/uv/python/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/concurrent/futures/thread.py:73: in run
+    return fn(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^
+custom_components/firewalla_local/config_flow.py:168: in _resolve_default_pairing_host
+    addrinfo = socket.getaddrinfo(
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:227: in getaddrinfo_patched
+    _validate_host(host)
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+host = 'fire.walla'
+
+    def _validate_host(host):
+        if host in ("localhost", "127.0.0.1", "::1", None, "", "0.0.0.0", "::"):
+            return
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+>           raise RuntimeError("DNS resolution disabled in tests") from None
+E           RuntimeError: DNS resolution disabled in tests
+
+/home/vscode/.local/ha-venv/lib/python3.14/site-packages/pytest_homeassistant_custom_component/plugins.py:224: RuntimeError
+---------------------------- Captured stderr setup -----------------------------
+DEBUG:asyncio:Using selector: EpollSelector
+DEBUG:homeassistant.helpers.restore_state:Not creating cache - no saved states found
+------------------------------ Captured log setup ------------------------------
+DEBUG    asyncio:selector_events.py:64 Using selector: EpollSelector
+DEBUG    homeassistant.helpers.restore_state:restore_state.py:156 Not creating cache - no saved states found
+----------------------------- Captured stderr call -----------------------------
+INFO:homeassistant.loader:Loaded firewalla_local from custom_components.firewalla_local
+WARNING:homeassistant.loader:We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG:homeassistant.loader:Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+------------------------------ Captured log call -------------------------------
+INFO     homeassistant.loader:loader.py:785 Loaded firewalla_local from custom_components.firewalla_local
+WARNING  homeassistant.loader:loader.py:700 We found a custom integration firewalla_local which has not been tested by Home Assistant. This component might cause stability problems, be sure to disable it if you experience issues with Home Assistant
+DEBUG    homeassistant.loader:loader.py:1202 Importing platforms for firewalla_local executor=[] loop=['config_flow'] took 0.00s
+--------------------------- Captured stderr teardown ---------------------------
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_stop[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG:homeassistant.core:Bus:Handling <Event homeassistant_close[L]>
+DEBUG:asyncio:Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+---------------------------- Captured log teardown -----------------------------
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_stop[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_final_write[L]>
+DEBUG    homeassistant.core:core.py:1520 Bus:Handling <Event homeassistant_close[L]>
+DEBUG    asyncio:base_events.py:742 Close <_UnixSelectorEventLoop running=False closed=False debug=True>
+=========================== short test summary info ============================
+FAILED tests/components/firewalla_local/test_config_flow.py::test_user_flow_creates_entry
+FAILED tests/components/firewalla_local/test_config_flow.py::test_duplicate_license_aborts
+FAILED tests/components/firewalla_local/test_config_flow.py::test_invalid_qr_shows_form_error
+FAILED tests/components/firewalla_local/test_config_flow.py::test_invalid_qr_shows_qr_error
+FAILED tests/components/firewalla_local/test_config_flow.py::test_user_flow_cannot_connect_shows_form_error
+FAILED tests/components/firewalla_local/test_config_flow.py::test_user_flow_cloud_link_timeout_shows_specific_error
+FAILED tests/components/firewalla_local/test_config_flow.py::test_user_flow_retries_local_runtime_activation_on_http_412
+FAILED tests/components/firewalla_local/test_config_flow.py::test_user_flow_local_runtime_timeout_shows_specific_error
+FAILED tests/components/firewalla_local/test_config_flow.py::test_user_flow_logs_local_pairing_wait_details
+FAILED tests/components/firewalla_local/test_config_flow.py::test_user_flow_retries_local_runtime_disconnect_during_activation
+FAILED tests/components/firewalla_local/test_config_flow.py::test_user_flow_logs_local_disconnect_wait_details
+FAILED tests/components/firewalla_local/test_config_flow.py::test_user_flow_logs_pairing_failure_details
+======================== 12 failed, 203 passed in 7.91s ========================

--- a/tests/components/firewalla_local/test_client.py
+++ b/tests/components/firewalla_local/test_client.py
@@ -456,7 +456,7 @@ async def test_get_runtime_snapshot_normalizes_policy_rules() -> None:
     assert rules[1].target_name == "DAP - 00:08:9B:FB:01:D9"
     assert rules[2].target_name == "VLAN10 CORE"
     assert rules[3].target_name == "Quarantine"
-    assert rules[4].applies_to == ("KADEN's Devices (KADEN)",)
+    assert rules[4].applies_to == ("KADEN",)
     assert rules[5].target_name == "social"
     assert rules[5].tag_refs == ("tag:12",)
     assert rules[5].activated_time == 1774299013.0
@@ -958,6 +958,79 @@ async def test_get_runtime_snapshot_prefers_internet_usage_totals_for_users() ->
                     unique_minutes=2,
                 ),
             ),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_runtime_snapshot_uses_affiliated_user_names_and_app_name_for_rules() -> (
+    None
+):
+    """Test rule normalization prefers affiliated user names and app names."""
+    async with ClientSession() as session:
+        client = FirewallaApiClient(
+            session=session,
+            host="192.168.200.1",
+            gid="gid-123",
+            eid="eid-123",
+            aid="aid-123",
+            symmetric_key=TEST_SYMMETRIC_KEY,
+            device_name="Home Assistant",
+        )
+        with patch.object(
+            client,
+            "_async_send_local_message",
+            AsyncMock(
+                return_value={
+                    "groupName": "Firewalla",
+                    "model": "gold",
+                    "cpuid": "serial-123",
+                    "longVersion": "1.0.0",
+                    "tags": {
+                        "10": {"name": "KADEN's Devices"},
+                    },
+                    "userTags": {"21": {"name": "KADEN", "affiliatedTag": "10"}},
+                    "policyRules": [
+                        {
+                            "pid": "741",
+                            "action": "block",
+                            "target": "TLX-fw-instagram",
+                            "type": "category",
+                            "direction": "outbound",
+                            "disabled": "0",
+                            "tag": ["tag:10"],
+                            "app_name": "instagram",
+                        }
+                    ],
+                    "exceptionRules": [],
+                }
+            ),
+        ):
+            snapshot = await client.async_get_runtime_snapshot()
+
+    assert snapshot.policy_rules == (
+        FirewallaPolicyRule(
+            rule_id="741",
+            action="block",
+            target="TLX-fw-instagram",
+            target_type="category",
+            direction="outbound",
+            enabled=True,
+            purpose=None,
+            scope=(),
+            applies_to=("KADEN",),
+            tag_refs=("tag:10",),
+            target_name="Instagram",
+            raw_update_payload={
+                "pid": "741",
+                "action": "block",
+                "target": "TLX-fw-instagram",
+                "type": "category",
+                "direction": "outbound",
+                "disabled": "0",
+                "tag": ["tag:10"],
+                "app_name": "instagram",
+            },
         ),
     )
 

--- a/tests/components/firewalla_local/test_client.py
+++ b/tests/components/firewalla_local/test_client.py
@@ -963,9 +963,7 @@ async def test_get_runtime_snapshot_prefers_internet_usage_totals_for_users() ->
 
 
 @pytest.mark.asyncio
-async def test_get_runtime_snapshot_uses_affiliated_user_names_and_app_name_for_rules() -> (
-    None
-):
+async def test_get_runtime_snapshot_uses_user_names_and_app_names() -> None:
     """Test rule normalization prefers affiliated user names and app names."""
     async with ClientSession() as session:
         client = FirewallaApiClient(

--- a/tests/components/firewalla_local/test_config_flow.py
+++ b/tests/components/firewalla_local/test_config_flow.py
@@ -24,7 +24,10 @@ from custom_components.firewalla_local.api.models import (
     FirewallaProvisionedCredentials,
     GeneratedKeys,
 )
-from custom_components.firewalla_local.config_flow import FirewallaOptionsFlow
+from custom_components.firewalla_local.config_flow import (
+    FirewallaOptionsFlow,
+    _resolve_default_pairing_host,
+)
 from custom_components.firewalla_local.const import (
     CONF_AID,
     CONF_DEVICE_TRACKER_AWAY_WINDOW,
@@ -150,6 +153,15 @@ async def test_user_flow_leaves_default_host_blank_when_resolution_fails(hass) -
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert _get_schema_default(result, CONF_HOST) == ""
+
+
+def test_resolve_default_pairing_host_returns_none_when_dns_is_disabled() -> None:
+    """Test default host resolution degrades cleanly when DNS is blocked."""
+    with patch(
+        "custom_components.firewalla_local.config_flow.socket.getaddrinfo",
+        side_effect=RuntimeError("DNS resolution disabled in tests"),
+    ):
+        assert _resolve_default_pairing_host() is None
 
 
 async def test_user_flow_creates_entry(hass) -> None:

--- a/tests/components/firewalla_local/test_models.py
+++ b/tests/components/firewalla_local/test_models.py
@@ -76,6 +76,24 @@ def test_format_policy_rule_name_hides_internal_qos_uuid() -> None:
     assert format_policy_rule_name(rule) == "qos category QoS Zoom"
 
 
+def test_format_policy_rule_name_hides_app_category_target_slug() -> None:
+    """Test app-backed category labels avoid leaking raw TLX target slugs."""
+    rule = FirewallaPolicyRule(
+        rule_id="5a",
+        action="block",
+        target="TLX-fw-instagram",
+        target_type="category",
+        direction="outbound",
+        enabled=True,
+        purpose=None,
+        scope=(),
+        applies_to=("PAYTONS_PHONE",),
+        target_name="Instagram",
+    )
+
+    assert format_policy_rule_name(rule) == "block category Instagram for PAYTONS_PHONE"
+
+
 def test_format_policy_rule_name_prefers_custom_name() -> None:
     """Test a user-defined custom rule name overrides generated labels."""
     rule = FirewallaPolicyRule(


### PR DESCRIPTION
## Summary

Describe what changed and why.
This pull request introduces improvements to how policy rules are normalized and displayed, particularly for app-backed category rules and affiliated user names. It also adds robustness to DNS resolution in the configuration flow, updates the version to 1.1.6, and enhances test coverage for these changes.

**Policy Rule Normalization and Display Improvements:**

* Added support for extracting and displaying the `app_name` for app-backed category rules, providing a cleaner and more user-friendly rule name instead of exposing internal identifiers. (`custom_components/firewalla_local/api/client.py`, `custom_components/firewalla_local/models.py`) [[1]](diffhunk://#diff-6f0f34e6f7600b33fac3b655d201469cba2422831c28567427d89eb66718c862R99) [[2]](diffhunk://#diff-991e5e6b0abd77890b2e5eb49089523c4d2124adc4c7f794dded231301490377R82) [[3]](diffhunk://#diff-991e5e6b0abd77890b2e5eb49089523c4d2124adc4c7f794dded231301490377R1240-R1247) [[4]](diffhunk://#diff-6f0f34e6f7600b33fac3b655d201469cba2422831c28567427d89eb66718c862R1845-R1847)
* Improved handling of affiliated user names in group-based rules, ensuring that only user names (not group names) are shown in the `applies_to` field. (`custom_components/firewalla_local/api/client.py`, `tests/components/firewalla_local/test_client.py`) [[1]](diffhunk://#diff-6f0f34e6f7600b33fac3b655d201469cba2422831c28567427d89eb66718c862L1752-R1755) [[2]](diffhunk://#diff-03757d0b25392fbb2c284ab02005a69616a35f0fe6ff954192c63112a2c8ab93L459-R459)

**Robustness and Testing:**

* Updated the default pairing host resolution to gracefully handle both `OSError` and `RuntimeError`, preventing failures when DNS is blocked, and added a test to cover this scenario. (`custom_components/firewalla_local/config_flow.py`, `tests/components/firewalla_local/test_config_flow.py`) [[1]](diffhunk://#diff-55994e351d64b565b19c71b0af56d19b099f2c744ca26730cb1615e43ec9d10bL174-R174) [[2]](diffhunk://#diff-73ee5aa09f0dfa4959ed2f07f661bbaf91fa1c4dd21e3f5d65b245b4212540beR158-R166)

**Versioning and Development Environment:**

* Bumped the integration version to `1.1.6` in both `manifest.json` and `pyproject.toml`. [[1]](diffhunk://#diff-5839a5201f0acd106bd803dffd506cf394aa2aef82256af5c24b33ff7f2b6373L12-R12) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7)
* Updated the development workspace task to ensure an `__init__.py` is present for custom components. (`firewalla-dev.code-workspace`)

**Test Coverage:**

* Added and updated tests to verify the improved normalization of policy rules, including app-backed categories and affiliated user names, and to ensure internal slugs are hidden from user-facing labels. (`tests/components/firewalla_local/test_client.py`, `tests/components/firewalla_local/test_models.py`) [[1]](diffhunk://#diff-03757d0b25392fbb2c284ab02005a69616a35f0fe6ff954192c63112a2c8ab93R965-R1037) [[2]](diffhunk://#diff-224e823f57cb24601b903f1a9013216ab5c0a0c36ac582cea88f025f83e7e179R79-R96)

## Validation

- [x] `bash ./utils/quick_lint.sh`
- [x] `python -m mypy custom_components/firewalla_local`
- [x] `python -m pytest tests/ -v`

## Issue linkage

Closes #10