### PR TITLE
feat: add rule applicability and shared entity metadata

### DIFF
--- a/custom_components/firewalla_local/api/client.py
+++ b/custom_components/firewalla_local/api/client.py
@@ -1164,6 +1164,39 @@ class FirewallaApiClient:
 
         return category_lookup
 
+    def _build_app_category_lookup(self, data: dict[str, object]) -> dict[str, str]:
+        """Build a lookup of app identifiers to their reported category names."""
+        raw_user_tags = data.get(_RAW_USER_TAGS_KEY)
+        if not isinstance(raw_user_tags, dict):
+            return {}
+
+        app_category_lookup: dict[str, str] = {}
+        for raw_user in raw_user_tags.values():
+            if not isinstance(raw_user, dict):
+                continue
+
+            raw_app_usage_today = raw_user.get(_RAW_USER_APP_TIME_USAGE_TODAY_KEY)
+            if not isinstance(raw_app_usage_today, dict):
+                continue
+
+            for app_id, raw_app_usage in raw_app_usage_today.items():
+                if app_id in {_RAW_USER_TOTAL_MINS_KEY, _RAW_USER_UNIQUE_MINS_KEY}:
+                    continue
+                if not isinstance(app_id, str) or not app_id:
+                    continue
+                if not isinstance(raw_app_usage, dict):
+                    continue
+                if app_id in app_category_lookup:
+                    continue
+
+                category = self._normalized_optional_string(
+                    raw_app_usage.get(_RAW_USER_CATEGORY_KEY)
+                )
+                if category is not None:
+                    app_category_lookup[app_id] = category
+
+        return app_category_lookup
+
     def _build_network_lookup(self, data: dict[str, object]) -> dict[str, str]:
         """Build a lookup of network UUIDs to readable network names."""
         raw_network_profiles = data.get(_RAW_NETWORK_PROFILES_KEY)
@@ -1742,24 +1775,30 @@ class FirewallaApiClient:
         user_tags: dict[str, str],
         networks: dict[str, str],
         affiliated_users: dict[str, tuple[str, ...]],
-    ) -> str | None:
-        """Resolve a Firewalla tag reference string into a readable name."""
+    ) -> tuple[str, str] | None:
+        """Resolve a Firewalla tag reference into a readable name and kind."""
         tag_prefix, _, tag_value = tag_reference.partition(_RAW_TAG_SEPARATOR)
         if not tag_value:
             return None
 
         if tag_prefix == _RAW_TAG_PREFIX_GROUP:
             if user_names := affiliated_users.get(tag_value):
-                return ", ".join(user_names)
+                return ", ".join(user_names), "user"
             if tag_name := tags.get(tag_value):
-                return tag_name
+                return tag_name, "group"
             return None
         if tag_prefix == _RAW_TAG_PREFIX_DEVICE:
-            return device_tags.get(tag_value)
+            if tag_name := device_tags.get(tag_value):
+                return tag_name, "device"
+            return None
         if tag_prefix in {_RAW_TAG_PREFIX_USER, _RAW_TAG_PREFIX_USER_ALT}:
-            return user_tags.get(tag_value)
+            if tag_name := user_tags.get(tag_value):
+                return tag_name, "user"
+            return None
         if tag_prefix == _RAW_TAG_PREFIX_NETWORK:
-            return networks.get(tag_value)
+            if tag_name := networks.get(tag_value):
+                return tag_name, "network"
+            return None
         return None
 
     def _resolve_rule_applicability(
@@ -1771,18 +1810,18 @@ class FirewallaApiClient:
         user_tags: dict[str, str],
         networks: dict[str, str],
         affiliated_users: dict[str, tuple[str, ...]],
-    ) -> tuple[str, ...]:
-        """Resolve tag-based rule applicability into readable labels."""
+    ) -> tuple[tuple[str, str], ...]:
+        """Resolve tag-based rule applicability into readable labels and kinds."""
         raw_tags = raw_rule.get(_RAW_RULE_TAGS_KEY)
         if not isinstance(raw_tags, list):
             return ()
 
         resolved_tags = [
-            resolved_name
+            resolved_entry
             for tag_reference in raw_tags
             if isinstance(tag_reference, str)
             and (
-                resolved_name := self._resolve_tag_reference_name(
+                resolved_entry := self._resolve_tag_reference_name(
                     tag_reference,
                     tags=tags,
                     device_tags=device_tags,
@@ -1818,11 +1857,11 @@ class FirewallaApiClient:
                 raw_tags = raw_rule.get(_RAW_RULE_TAGS_KEY)
                 if isinstance(raw_tags, list):
                     resolved_tags = [
-                        resolved_name
+                        resolved_entry[0]
                         for tag_reference in raw_tags
                         if isinstance(tag_reference, str)
                         and (
-                            resolved_name := self._resolve_tag_reference_name(
+                            resolved_entry := self._resolve_tag_reference_name(
                                 tag_reference,
                                 tags=tags,
                                 device_tags=device_tags,
@@ -1911,6 +1950,7 @@ class FirewallaApiClient:
             return ()
 
         category_lookup = self._build_category_lookup(data)
+        app_category_lookup = self._build_app_category_lookup(data)
         network_lookup = self._build_network_lookup(data)
         tag_lookup = self._build_named_lookup(data, "tags")
         device_tag_lookup = self._build_named_lookup(data, _RAW_DEVICE_TAGS_KEY)
@@ -1986,6 +2026,9 @@ class FirewallaApiClient:
                 hosts=host_lookup,
                 affiliated_users=affiliated_user_lookup,
             )
+            app_name = self._normalized_optional_string(
+                raw_rule.get(_RAW_RULE_APP_NAME_KEY)
+            )
             applies_to = self._resolve_rule_applicability(
                 raw_rule,
                 tags=tag_lookup,
@@ -1993,6 +2036,14 @@ class FirewallaApiClient:
                 user_tags=user_tag_lookup,
                 networks=network_lookup,
                 affiliated_users=affiliated_user_lookup,
+            )
+            category = (
+                app_category_lookup.get(app_name)
+                if (
+                    raw_target_type == _RULE_TARGET_TYPE_CATEGORY
+                    and app_name is not None
+                )
+                else None
             )
 
             normalized_rules.append(
@@ -2007,7 +2058,8 @@ class FirewallaApiClient:
                     scope=scope,
                     tag_refs=tag_refs,
                     target_name=target_name,
-                    applies_to=applies_to,
+                    applies_to=tuple(name for name, _kind in applies_to),
+                    applies_to_kind=tuple(kind for _name, kind in applies_to),
                     activated_time=activated_time,
                     updated_time=updated_time,
                     last_activated_time=last_activated_time,
@@ -2015,6 +2067,7 @@ class FirewallaApiClient:
                     expires_at=expires_at,
                     auto_delete_when_expires=auto_delete_when_expires,
                     dnsmasq_only=dnsmasq_only,
+                    category=category,
                     raw_update_payload=dict(raw_rule),
                 )
             )

--- a/custom_components/firewalla_local/binary_sensor.py
+++ b/custom_components/firewalla_local/binary_sensor.py
@@ -12,7 +12,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import (
-    ATTR_PURPOSE,
     ATTR_SYSTEM_BOOT_COMPLETE,
     ATTR_SYSTEM_BOX_IMAGE_CODENAME,
     ATTR_SYSTEM_BOX_IMAGE_VERSION,
@@ -104,7 +103,7 @@ class FirewallaSystemStatusBinarySensor(FirewallaEntity, BinarySensorEntity):
         """Return stable system-status metadata attributes."""
         system_status = self.system_status
         return {
-            ATTR_PURPOSE: TRANS_KEY_PURPOSE_SYSTEM_BOOT_STATUS,
+            **self.build_state_attributes(TRANS_KEY_PURPOSE_SYSTEM_BOOT_STATUS),
             ATTR_SYSTEM_UPTIME: (
                 self._format_uptime(system_status.uptime_seconds)
                 if system_status is not None
@@ -260,7 +259,9 @@ class FirewallaWatchedDeviceBinarySensor(FirewallaEntity, BinarySensorEntity):
         """Return bounded watched-device metadata attributes."""
         host = self._host
         return {
-            ATTR_PURPOSE: TRANS_KEY_PURPOSE_WATCHED_DEVICE_CONNECTIVITY,
+            **self.build_state_attributes(
+                TRANS_KEY_PURPOSE_WATCHED_DEVICE_CONNECTIVITY
+            ),
             ATTR_WATCHED_DEVICE_IP_ADDRESS: (
                 host.ip_address if host is not None else None
             ),

--- a/custom_components/firewalla_local/button.py
+++ b/custom_components/firewalla_local/button.py
@@ -11,6 +11,7 @@ from .const import (
     ENTITY_SUFFIX_BUTTON,
     LOGGER,
     TRANS_KEY_ENTITY_BUTTON_SYNC_RUNTIME,
+    TRANS_KEY_PURPOSE_RUNTIME_SYNC_BUTTON,
 )
 from .coordinator import FirewallaConfigEntry
 from .entity import FirewallaEntity
@@ -47,6 +48,11 @@ class FirewallaSyncRuntimeButton(FirewallaEntity, ButtonEntity):
             object_id=_SYNC_RUNTIME_OBJECT_ID,
             suffix=ENTITY_SUFFIX_BUTTON,
         )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        """Return bounded button metadata attributes."""
+        return self.build_state_attributes(TRANS_KEY_PURPOSE_RUNTIME_SYNC_BUTTON)
 
     async def async_press(self) -> None:
         """Request an immediate coordinator refresh."""

--- a/custom_components/firewalla_local/const.py
+++ b/custom_components/firewalla_local/const.py
@@ -11,10 +11,14 @@ LOGGER: Final = logging.getLogger(__name__)
 MANUFACTURER: Final = "Firewalla"
 
 # Entity state attributes
+ATTR_INTEGRATION: Final = "integration"
 ATTR_PURPOSE: Final = "purpose"
 ATTR_RULE_PURPOSE: Final = "purpose"
 ATTR_RULE_ID: Final = "rule_id"
 ATTR_RULE_NAME: Final = "rule_name"
+ATTR_RULE_APPLIES_TO: Final = "applies_to"
+ATTR_RULE_APPLIES_TO_KIND: Final = "applies_to_kind"
+ATTR_RULE_CATEGORY: Final = "category"
 ATTR_RULE_CUSTOM_NAME: Final = "custom_name"
 ATTR_RULE_ACTION: Final = "action"
 ATTR_RULE_TEMPLATE_TARGET: Final = "target"
@@ -357,6 +361,7 @@ TRANS_KEY_PURPOSE_WATCHED_DEVICE_CONNECTIVITY: Final = (
 )
 TRANS_KEY_PURPOSE_WATCHED_USER_USAGE: Final = "purpose_watched_user_usage"
 TRANS_KEY_PURPOSE_SPEED_TEST: Final = "purpose_speed_test"
+TRANS_KEY_PURPOSE_RUNTIME_SYNC_BUTTON: Final = "purpose_runtime_sync_button"
 TRANS_KEY_PURPOSE_RULE_SWITCH: Final = "purpose_rule_control"
 TRANS_KEY_OPTION_LABEL_UNAVAILABLE_DEVICE: Final = "unavailable_device"
 TRANS_KEY_OPTION_LABEL_UNAVAILABLE_DEVICE_TRACKER: Final = "unavailable_device_tracker"

--- a/custom_components/firewalla_local/device_tracker.py
+++ b/custom_components/firewalla_local/device_tracker.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
 
 from .const import (
-    ATTR_PURPOSE,
+    ATTR_INTEGRATION,
     ATTR_WATCHED_DEVICE_CONNECTION_TYPE,
     ATTR_WATCHED_DEVICE_DEVICE_GROUP,
     ATTR_WATCHED_DEVICE_DNS_DOMAIN,
@@ -25,6 +25,7 @@ from .const import (
     ATTR_WATCHED_DEVICE_IP_ADDRESS,
     ATTR_WATCHED_DEVICE_LAST_ACTIVE,
     ATTR_WATCHED_DEVICE_NETWORK_NAME,
+    DOMAIN,
     ENTITY_SUFFIX_DEVICE_TRACKER,
     TRANS_KEY_ENTITY_DEVICE_TRACKER_PRESENCE,
     TRANS_KEY_PURPOSE_DEVICE_TRACKER_PRESENCE,
@@ -85,6 +86,13 @@ class FirewallaDeviceTracker(
     def entity_category(self) -> EntityCategory | None:
         """Return the entity category for this tracker."""
         return None
+
+    def _build_state_attributes(self, purpose: str) -> dict[str, object]:
+        """Return the common identifying state attributes for this tracker."""
+        return {
+            "purpose": purpose,
+            ATTR_INTEGRATION: DOMAIN,
+        }
 
     def find_device_entry(self) -> dr.DeviceEntry | None:
         """Return the tracked-client device entry for this tracker."""
@@ -179,7 +187,7 @@ class FirewallaDeviceTracker(
         """Return bounded device-tracker metadata attributes."""
         host = self._host
         return {
-            ATTR_PURPOSE: TRANS_KEY_PURPOSE_DEVICE_TRACKER_PRESENCE,
+            **self._build_state_attributes(TRANS_KEY_PURPOSE_DEVICE_TRACKER_PRESENCE),
             ATTR_WATCHED_DEVICE_IP_ADDRESS: (
                 host.ip_address if host is not None else None
             ),

--- a/custom_components/firewalla_local/entity.py
+++ b/custom_components/firewalla_local/entity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .const import ATTR_INTEGRATION, ATTR_PURPOSE, DOMAIN
 from .coordinator import FirewallaConfigEntry, FirewallaDataUpdateCoordinator
 from .managers import (
     FirewallaHostManager,
@@ -82,3 +83,15 @@ class FirewallaEntity(CoordinatorEntity[FirewallaDataUpdateCoordinator]):
     def available(self) -> bool:
         """Return coordinator-backed availability for Firewalla entities."""
         return super().available and self.coordinator.data is not None
+
+    def build_state_attributes(
+        self,
+        purpose: str,
+        *,
+        purpose_key: str = ATTR_PURPOSE,
+    ) -> dict[str, object]:
+        """Return the common identifying state attributes for one entity."""
+        return {
+            purpose_key: purpose,
+            ATTR_INTEGRATION: DOMAIN,
+        }

--- a/custom_components/firewalla_local/models.py
+++ b/custom_components/firewalla_local/models.py
@@ -852,6 +852,7 @@ class FirewallaPolicyRule:
     tag_refs: tuple[str, ...] = ()
     target_name: str | None = None
     applies_to: tuple[str, ...] = ()
+    applies_to_kind: tuple[str, ...] = ()
     activated_time: float | None = None
     updated_time: float | None = None
     last_activated_time: float | None = None
@@ -859,6 +860,7 @@ class FirewallaPolicyRule:
     expires_at: float | None = None
     auto_delete_when_expires: bool | None = None
     dnsmasq_only: bool | None = None
+    category: str | None = None
     raw_update_payload: dict[str, object] = field(default_factory=dict, compare=False)
 
     @property

--- a/custom_components/firewalla_local/sensor.py
+++ b/custom_components/firewalla_local/sensor.py
@@ -14,7 +14,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import (
-    ATTR_PURPOSE,
     ATTR_SPEED_TEST_DOWNLOAD_MBYTES,
     ATTR_SPEED_TEST_ISP,
     ATTR_SPEED_TEST_JITTER,
@@ -100,7 +99,7 @@ class FirewallaLatestSpeedTestDownloadSensor(FirewallaEntity, SensorEntity):
         """Return stable attributes describing the latest speed test."""
         speed_test = self.latest_speed_test
         return {
-            ATTR_PURPOSE: TRANS_KEY_PURPOSE_SPEED_TEST,
+            **self.build_state_attributes(TRANS_KEY_PURPOSE_SPEED_TEST),
             ATTR_SPEED_TEST_TESTED_AT: (
                 datetime.fromtimestamp(speed_test.tested_at_timestamp, UTC).isoformat()
                 if speed_test is not None
@@ -208,7 +207,7 @@ class FirewallaWatchedUserTodayUsageSensor(FirewallaEntity, SensorEntity):
         """Return bounded watched-user metadata attributes."""
         watched_user = self._watched_user
         return {
-            ATTR_PURPOSE: TRANS_KEY_PURPOSE_WATCHED_USER_USAGE,
+            **self.build_state_attributes(TRANS_KEY_PURPOSE_WATCHED_USER_USAGE),
             ATTR_WATCHED_USER_ASSOCIATED_DEVICE_GROUP: (
                 watched_user.affiliated_group_name if watched_user is not None else None
             ),

--- a/custom_components/firewalla_local/switch.py
+++ b/custom_components/firewalla_local/switch.py
@@ -11,6 +11,9 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     ATTR_RULE_ACTION,
+    ATTR_RULE_APPLIES_TO,
+    ATTR_RULE_APPLIES_TO_KIND,
+    ATTR_RULE_CATEGORY,
     ATTR_RULE_CURRENT_STATE_REASON,
     ATTR_RULE_CUSTOM_NAME,
     ATTR_RULE_ID,
@@ -136,10 +139,22 @@ class FirewallaRuleSwitch(FirewallaEntity, SwitchEntity):
             else None
         )
         attributes: dict[str, object] = {
-            ATTR_RULE_PURPOSE: TRANS_KEY_PURPOSE_RULE_SWITCH,
+            **self.build_state_attributes(
+                TRANS_KEY_PURPOSE_RULE_SWITCH,
+                purpose_key=ATTR_RULE_PURPOSE,
+            ),
             ATTR_RULE_ID: matched_rule.rule_id if matched_rule is not None else None,
             ATTR_RULE_NAME: self._template.name,
         }
+
+        if matched_rule is not None and matched_rule.applies_to:
+            attributes[ATTR_RULE_APPLIES_TO] = list(matched_rule.applies_to)
+
+        if matched_rule is not None and matched_rule.applies_to_kind:
+            attributes[ATTR_RULE_APPLIES_TO_KIND] = list(matched_rule.applies_to_kind)
+
+        if matched_rule is not None and matched_rule.category is not None:
+            attributes[ATTR_RULE_CATEGORY] = matched_rule.category
 
         if (
             matched_rule is not None

--- a/custom_components/firewalla_local/translations/en.json
+++ b/custom_components/firewalla_local/translations/en.json
@@ -115,6 +115,9 @@
       "system_status": {
         "name": "System Status",
         "state_attributes": {
+          "integration": {
+            "name": "Integration"
+          },
           "boot_complete": {
             "name": "Boot complete"
           },
@@ -186,6 +189,9 @@
       "watched_device": {
         "name": "{host_name}",
         "state_attributes": {
+          "integration": {
+            "name": "Integration"
+          },
           "purpose": {
             "name": "Purpose",
             "state": {
@@ -218,13 +224,27 @@
     },
     "button": {
       "sync_runtime": {
-        "name": "Sync runtime"
+        "name": "Sync runtime",
+        "state_attributes": {
+          "integration": {
+            "name": "Integration"
+          },
+          "purpose": {
+            "name": "Purpose",
+            "state": {
+              "purpose_runtime_sync_button": "Requests an immediate refresh of the Firewalla runtime snapshot"
+            }
+          }
+        }
       }
     },
     "device_tracker": {
       "presence": {
         "name": "Presence",
         "state_attributes": {
+          "integration": {
+            "name": "Integration"
+          },
           "purpose": {
             "name": "Purpose",
             "state": {
@@ -253,6 +273,9 @@
       "latest_speed_test_download": {
         "name": "Speed Test",
         "state_attributes": {
+          "integration": {
+            "name": "Integration"
+          },
           "purpose": {
             "name": "Purpose",
             "state": {
@@ -315,6 +338,9 @@
       "watched_user_today_usage": {
         "name": "{user_name} Usage",
         "state_attributes": {
+          "integration": {
+            "name": "Integration"
+          },
           "purpose": {
             "name": "Purpose",
             "state": {
@@ -346,11 +372,23 @@
       "allow_rule": {
         "name": "{rule_name}",
         "state_attributes": {
+          "integration": {
+            "name": "Integration"
+          },
           "purpose": {
             "name": "Purpose",
             "state": {
               "purpose_rule_control": "Pauses or resumes the firewall rule"
             }
+          },
+          "applies_to": {
+            "name": "Applies to"
+          },
+          "applies_to_kind": {
+            "name": "Applies to kind"
+          },
+          "category": {
+            "name": "Category"
           },
           "rule_name": {
             "name": "Rule name"
@@ -423,11 +461,23 @@
       "block_rule": {
         "name": "{rule_name}",
         "state_attributes": {
+          "integration": {
+            "name": "Integration"
+          },
           "purpose": {
             "name": "Purpose",
             "state": {
               "purpose_rule_control": "Pauses or resumes the firewall rule"
             }
+          },
+          "applies_to": {
+            "name": "Applies to"
+          },
+          "applies_to_kind": {
+            "name": "Applies to kind"
+          },
+          "category": {
+            "name": "Category"
           },
           "rule_name": {
             "name": "Rule name"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -87,6 +87,7 @@ Identity presentation rule:
 - when Firewalla exposes both an app-visible user identity and a backing group or tag used only to model assignment, Home Assistant-facing surfaces must prefer the user-facing identity
 - backing group names are implementation details unless the surface is explicitly diagnostic or inventory-oriented
 - this rule applies to normalized rule applicability, watched-user associations, and host-backed entity attributes derived from group membership
+- when normalized rule applicability uses an affiliated user identity in place of a backing group name, the accompanying applicability kind must also be `user` so label and kind stay aligned on Home Assistant-facing surfaces
 
 ## Protocol baseline
 

--- a/docs/DEVELOPMENT_STANDARDS.md
+++ b/docs/DEVELOPMENT_STANDARDS.md
@@ -56,6 +56,7 @@ User-facing identity rule:
 - when local payloads expose both a user-facing identity and an affiliated backing group or tag, prefer the user-facing identity for Home Assistant names and attributes
 - treat backing group names as implementation detail unless the current surface is explicitly diagnostic, inventory-oriented, or otherwise intended to expose raw Firewalla structure
 - do not concatenate backing group names into entity or attribute labels just because the raw payload links the user through that group
+- when a rule `applies_to` label is intentionally rewritten from a backing group to the affiliated user identity, `applies_to_kind` must also be rewritten to `user` rather than preserving the raw backing-group kind
 
 ## Constants taxonomy
 

--- a/docs/REVERSE_ENGINEERING_WORKFLOW.md
+++ b/docs/REVERSE_ENGINEERING_WORKFLOW.md
@@ -116,6 +116,12 @@ This helper:
 Use this first when the question is about what the box reports right now, for
 example current user usage fields or the exact contents of `userTags`.
 
+Applicability interpretation note:
+
+- local rule payloads may still express direct-to-user assignment through a backing group tag plus affiliated user metadata
+- when that happens, Home Assistant-facing rule applicability should record both the readable label and the applicability kind as `user`
+- preserve the raw backing group reference only in diagnostic or capture artifacts, not in the default Home Assistant-facing applicability attributes
+
 ### Runtime inventory capture helper
 
 - `.tmp/capture_runtime_inventory.py`

--- a/docs/RULE_MODEL.md
+++ b/docs/RULE_MODEL.md
@@ -86,6 +86,7 @@ Identity interpretation rule:
 
 - when local rule payloads identify applicability through a backing group or tag that has affiliated user metadata, the Home Assistant-facing readable name should prefer the affiliated user identity over the backing group name
 - raw backing group names remain valid inventory or diagnostic evidence, but they are not the default presentation contract for rule names or related metadata
+- when rule applicability is rewritten this way, the exposed applicability kind must follow the rewritten Home Assistant-facing identity and be reported as `user`, not `group`
 
 ### Practical design consequence
 

--- a/tests/components/firewalla_local/test_binary_sensor.py
+++ b/tests/components/firewalla_local/test_binary_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.firewalla_local.const import (
+    ATTR_INTEGRATION,
     ATTR_PURPOSE,
     ATTR_WATCHED_DEVICE_CONNECTION_TYPE,
     ATTR_WATCHED_DEVICE_DEVICE_GROUP,
@@ -134,6 +135,7 @@ async def test_watched_device_binary_sensor_exposes_state_and_attributes(
         watched_state.attributes[ATTR_PURPOSE]
         == TRANS_KEY_PURPOSE_WATCHED_DEVICE_CONNECTIVITY
     )
+    assert watched_state.attributes[ATTR_INTEGRATION] == DOMAIN
     assert watched_state.attributes[ATTR_WATCHED_DEVICE_IP_ADDRESS] == "192.168.200.25"
     assert watched_state.attributes[ATTR_WATCHED_DEVICE_DEVICE_GROUP] == "KADEN"
     assert watched_state.attributes[ATTR_WATCHED_DEVICE_NETWORK_NAME] == "VLAN10 CORE"

--- a/tests/components/firewalla_local/test_client.py
+++ b/tests/components/firewalla_local/test_client.py
@@ -306,7 +306,19 @@ async def test_get_runtime_snapshot_normalizes_policy_rules() -> None:
                             "vendor": "ookla",
                         },
                     ],
-                    "userTags": {"21": {"name": "KADEN", "affiliatedTag": "10"}},
+                    "userTags": {
+                        "21": {
+                            "name": "KADEN",
+                            "affiliatedTag": "10",
+                            "appTimeUsageToday": {
+                                "instagram": {
+                                    "category": "social",
+                                    "totalMins": 12,
+                                    "uniqueMins": 12,
+                                }
+                            },
+                        }
+                    },
                     "exceptionRules": [{"aid": "1"}, {"aid": "2"}],
                     "policyRules": [
                         {
@@ -515,7 +527,19 @@ async def test_get_runtime_snapshot_normalizes_host_inventory() -> None:
                     "tags": {
                         "10": {"name": "KADEN's Devices"},
                     },
-                    "userTags": {"21": {"name": "KADEN", "affiliatedTag": "10"}},
+                    "userTags": {
+                        "21": {
+                            "name": "KADEN",
+                            "affiliatedTag": "10",
+                            "appTimeUsageToday": {
+                                "instagram": {
+                                    "category": "social",
+                                    "totalMins": 12,
+                                    "uniqueMins": 12,
+                                }
+                            },
+                        }
+                    },
                     "deviceTags": {
                         "43": {"name": "phone"},
                     },
@@ -987,7 +1011,19 @@ async def test_get_runtime_snapshot_uses_user_names_and_app_names() -> None:
                     "tags": {
                         "10": {"name": "KADEN's Devices"},
                     },
-                    "userTags": {"21": {"name": "KADEN", "affiliatedTag": "10"}},
+                    "userTags": {
+                        "21": {
+                            "name": "KADEN",
+                            "affiliatedTag": "10",
+                            "appTimeUsageToday": {
+                                "instagram": {
+                                    "category": "social",
+                                    "totalMins": 12,
+                                    "uniqueMins": 12,
+                                }
+                            },
+                        }
+                    },
                     "policyRules": [
                         {
                             "pid": "741",
@@ -1017,8 +1053,10 @@ async def test_get_runtime_snapshot_uses_user_names_and_app_names() -> None:
             purpose=None,
             scope=(),
             applies_to=("KADEN",),
+            applies_to_kind=("user",),
             tag_refs=("tag:10",),
             target_name="Instagram",
+            category="social",
             raw_update_payload={
                 "pid": "741",
                 "action": "block",

--- a/tests/components/firewalla_local/test_device_tracker.py
+++ b/tests/components/firewalla_local/test_device_tracker.py
@@ -13,6 +13,7 @@ from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.firewalla_local.const import (
+    ATTR_INTEGRATION,
     ATTR_PURPOSE,
     ATTR_WATCHED_DEVICE_CONNECTION_TYPE,
     ATTR_WATCHED_DEVICE_DEVICE_GROUP,
@@ -177,6 +178,7 @@ async def test_device_tracker_exposes_state_and_attributes(
         tracker_state.attributes[ATTR_PURPOSE]
         == TRANS_KEY_PURPOSE_DEVICE_TRACKER_PRESENCE
     )
+    assert tracker_state.attributes[ATTR_INTEGRATION] == DOMAIN
     assert tracker_state.attributes[ATTR_WATCHED_DEVICE_IP_ADDRESS] == "192.168.200.25"
     assert tracker_state.attributes[ATTR_WATCHED_DEVICE_DEVICE_GROUP] == "KADEN"
     assert tracker_state.attributes[ATTR_WATCHED_DEVICE_NETWORK_NAME] == "VLAN10 CORE"

--- a/tests/components/firewalla_local/test_init.py
+++ b/tests/components/firewalla_local/test_init.py
@@ -20,6 +20,8 @@ from custom_components.firewalla_local.api.exceptions import (
     FirewallaConnectionError,
 )
 from custom_components.firewalla_local.const import (
+    ATTR_INTEGRATION,
+    ATTR_PURPOSE,
     CONF_AID,
     CONF_DEVICE_TRACKER_AWAY_WINDOW,
     CONF_DEVICE_TRACKERS,
@@ -57,6 +59,7 @@ from custom_components.firewalla_local.const import (
     SERVICE_SET_HOST_NOTIFY_WHEN_NEXT_OFFLINE,
     SERVICE_SET_HOST_NOTIFY_WHEN_NEXT_ONLINE,
     SERVICE_WAKE_HOST,
+    TRANS_KEY_PURPOSE_RUNTIME_SYNC_BUTTON,
 )
 from custom_components.firewalla_local.models import (
     FirewallaApplianceIdentityInput,
@@ -256,6 +259,12 @@ async def test_setup_entry_creates_runtime_sync_button(hass: HomeAssistant) -> N
 
     button_entry = entity_registry.async_get(button_entity_id)
     assert button_entry is not None
+    button_state = hass.states.get(button_entity_id)
+    assert button_state is not None
+    assert (
+        button_state.attributes[ATTR_PURPOSE] == TRANS_KEY_PURPOSE_RUNTIME_SYNC_BUTTON
+    )
+    assert button_state.attributes[ATTR_INTEGRATION] == DOMAIN
 
     device_registry = dr.async_get(hass)
     router_device = device_registry.async_get_device(

--- a/tests/components/firewalla_local/test_sensor.py
+++ b/tests/components/firewalla_local/test_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.firewalla_local.const import (
+    ATTR_INTEGRATION,
     ATTR_PURPOSE,
     ATTR_SPEED_TEST_DOWNLOAD_MBYTES,
     ATTR_SPEED_TEST_ISP,
@@ -314,6 +315,7 @@ async def test_sensor_setup_exposes_system_status_and_speed_test(
     assert system_state.state == STATE_ON
     attribute_keys = list(system_state.attributes)
     assert system_state.attributes[ATTR_PURPOSE] == TRANS_KEY_PURPOSE_SYSTEM_BOOT_STATUS
+    assert system_state.attributes[ATTR_INTEGRATION] == DOMAIN
     assert system_state.attributes[ATTR_SYSTEM_BOOT_COMPLETE] is True
     assert attribute_keys.index(
         ATTR_SYSTEM_BOX_IMAGE_VERSION
@@ -366,6 +368,7 @@ async def test_sensor_setup_exposes_system_status_and_speed_test(
     assert speedtest_state.name == "Firewalla Speed Test"
     assert float(speedtest_state.state) == pytest.approx(507.17651748657227)
     assert speedtest_state.attributes[ATTR_PURPOSE] == TRANS_KEY_PURPOSE_SPEED_TEST
+    assert speedtest_state.attributes[ATTR_INTEGRATION] == DOMAIN
     assert speedtest_state.attributes[ATTR_SPEED_TEST_ISP] == "Atlantic Broadband"
     assert speedtest_state.attributes[ATTR_SPEED_TEST_PUBLIC_IP] == "23.245.207.179"
     assert speedtest_state.attributes[ATTR_SPEED_TEST_UPLOAD] == 49.001976013183594
@@ -451,6 +454,7 @@ async def test_sensor_setup_handles_missing_speed_test_history(
     assert system_state is not None
     assert system_state.state == STATE_ON
     assert system_state.attributes[ATTR_PURPOSE] == TRANS_KEY_PURPOSE_SYSTEM_BOOT_STATUS
+    assert system_state.attributes[ATTR_INTEGRATION] == DOMAIN
     assert system_state.attributes[ATTR_SYSTEM_BOOT_COMPLETE] is False
     assert system_state.attributes[ATTR_SYSTEM_BOX_IMAGE_CODENAME] == "bionic"
     assert (
@@ -488,6 +492,7 @@ async def test_sensor_setup_handles_missing_speed_test_history(
     assert speedtest_state.state == "unknown"
     assert speedtest_state.name == "Firewalla Speed Test"
     assert speedtest_state.attributes[ATTR_PURPOSE] == TRANS_KEY_PURPOSE_SPEED_TEST
+    assert speedtest_state.attributes[ATTR_INTEGRATION] == DOMAIN
 
 
 async def test_sensor_setup_exposes_watched_user_usage_sensor(
@@ -604,6 +609,7 @@ async def test_sensor_setup_exposes_watched_user_usage_sensor(
         watched_user_state.attributes[ATTR_PURPOSE]
         == TRANS_KEY_PURPOSE_WATCHED_USER_USAGE
     )
+    assert watched_user_state.attributes[ATTR_INTEGRATION] == DOMAIN
     assert (
         watched_user_state.attributes[ATTR_WATCHED_USER_ASSOCIATED_DEVICE_GROUP]
         == "KADEN"

--- a/tests/components/firewalla_local/test_switch.py
+++ b/tests/components/firewalla_local/test_switch.py
@@ -10,7 +10,11 @@ from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.firewalla_local.const import (
+    ATTR_INTEGRATION,
     ATTR_RULE_ACTION,
+    ATTR_RULE_APPLIES_TO,
+    ATTR_RULE_APPLIES_TO_KIND,
+    ATTR_RULE_CATEGORY,
     ATTR_RULE_CURRENT_STATE_REASON,
     ATTR_RULE_CUSTOM_NAME,
     ATTR_RULE_ID,
@@ -66,6 +70,7 @@ def _snapshot_with_rule(
     target_type: str = "category",
     target_name: str | None = "social",
     applies_to: tuple[str, ...] = ("AV_SMART_TV",),
+    applies_to_kind: tuple[str, ...] = ("device",),
     tag_refs: tuple[str, ...] = ("tag:17",),
     dnsmasq_only: bool | None = True,
     auto_delete_when_expires: bool | None = None,
@@ -102,6 +107,7 @@ def _snapshot_with_rule(
                 tag_refs=tag_refs,
                 target_name=target_name,
                 applies_to=applies_to,
+                applies_to_kind=applies_to_kind,
                 auto_delete_when_expires=auto_delete_when_expires,
                 dnsmasq_only=dnsmasq_only,
                 raw_update_payload=raw_update_payload,
@@ -200,13 +206,19 @@ async def test_selected_rule_switch_turns_rule_off_and_on(hass: HomeAssistant) -
         assert state.state == "on"
         attributes = state.attributes
         assert attributes[ATTR_RULE_PURPOSE] == TRANS_KEY_PURPOSE_RULE_SWITCH
+        assert attributes[ATTR_INTEGRATION] == DOMAIN
         assert attributes[ATTR_RULE_ID] == "744"
         assert attributes[ATTR_RULE_NAME] == "block category social for AV_SMART_TV"
+        assert attributes[ATTR_RULE_APPLIES_TO] == ["AV_SMART_TV"]
+        assert attributes[ATTR_RULE_APPLIES_TO_KIND] == ["device"]
         assert next(iter(attributes)) == ATTR_RULE_PURPOSE
         assert _visible_attribute_keys(attributes) == [
             ATTR_RULE_PURPOSE,
+            ATTR_INTEGRATION,
             ATTR_RULE_ID,
             ATTR_RULE_NAME,
+            ATTR_RULE_APPLIES_TO,
+            ATTR_RULE_APPLIES_TO_KIND,
             ATTR_RULE_ACTION,
             ATTR_RULE_IS_PAUSED,
             ATTR_RULE_CURRENT_STATE_REASON,
@@ -261,6 +273,8 @@ async def test_selected_rule_switch_uses_live_custom_name(
         scope=(),
         tag_refs=("tag:17",),
         applies_to=("AV_SMART_TV",),
+        applies_to_kind=("device",),
+        category="social",
         raw_update_payload={
             "pid": "772",
             "action": "allow",
@@ -332,6 +346,10 @@ async def test_selected_rule_switch_uses_live_custom_name(
 
     assert state is not None
     assert state.name == "Firewalla ChoreOps Custom Allow"
+    assert state.attributes[ATTR_INTEGRATION] == DOMAIN
+    assert state.attributes[ATTR_RULE_APPLIES_TO] == ["AV_SMART_TV"]
+    assert state.attributes[ATTR_RULE_APPLIES_TO_KIND] == ["device"]
+    assert state.attributes[ATTR_RULE_CATEGORY] == "social"
     assert ATTR_RULE_CUSTOM_NAME not in state.attributes
 
 
@@ -622,7 +640,10 @@ async def test_selected_rule_switch_exposes_pause_and_notes_attributes(
     entity_id = next(iter(hass.states.async_entity_ids("switch")))
     attributes = hass.states.get(entity_id).attributes
     assert attributes[ATTR_RULE_PURPOSE] == TRANS_KEY_PURPOSE_RULE_SWITCH
+    assert attributes[ATTR_INTEGRATION] == DOMAIN
     assert attributes[ATTR_RULE_ID] == "744"
+    assert attributes[ATTR_RULE_APPLIES_TO] == ["AV_SMART_TV"]
+    assert attributes[ATTR_RULE_APPLIES_TO_KIND] == ["device"]
     assert attributes[ATTR_RULE_ACTION] == "block"
     assert attributes[ATTR_RULE_NOTES] == "Pause for maintenance"
     assert attributes[ATTR_RULE_IS_PAUSED] is True


### PR DESCRIPTION
This pull request introduces several improvements and new features to the Firewalla Local Home Assistant integration, focusing on more detailed rule metadata, enhanced attribute consistency, and internal code structure improvements. The most notable changes include adding support for rule applicability kinds and app categories, standardizing entity state attributes, and updating models and entity classes to support these enhancements.

**Policy rule metadata enhancements:**

* Added support for tracking both the names and kinds (e.g., user, device, group, network) of rule applicability, allowing for richer metadata in rule-related entities. [[1]](diffhunk://#diff-6f0f34e6f7600b33fac3b655d201469cba2422831c28567427d89eb66718c862L1745-R1801) [[2]](diffhunk://#diff-6f0f34e6f7600b33fac3b655d201469cba2422831c28567427d89eb66718c862L1774-R1824) [[3]](diffhunk://#diff-991e5e6b0abd77890b2e5eb49089523c4d2124adc4c7f794dded231301490377R855-R863) [[4]](diffhunk://#diff-dcdf7e5e2edce027910cff5c1ec4c0727d97fbaff84b295f6e576755f696e723L139-R158) [[5]](diffhunk://#diff-6ee521e8ffd685a4efd04867b49c2b10aeb63a51024b5ecb6d71a6899a829019R14-R21)
* Introduced app category extraction and association with rules, enabling entities to expose the category of an app targeted by a rule. [[1]](diffhunk://#diff-6f0f34e6f7600b33fac3b655d201469cba2422831c28567427d89eb66718c862R1167-R1199) [[2]](diffhunk://#diff-6f0f34e6f7600b33fac3b655d201469cba2422831c28567427d89eb66718c862R1953) [[3]](diffhunk://#diff-6f0f34e6f7600b33fac3b655d201469cba2422831c28567427d89eb66718c862R2029-R2031) [[4]](diffhunk://#diff-6f0f34e6f7600b33fac3b655d201469cba2422831c28567427d89eb66718c862R2040-R2047) [[5]](diffhunk://#diff-6f0f34e6f7600b33fac3b655d201469cba2422831c28567427d89eb66718c862L2010-R2070) [[6]](diffhunk://#diff-991e5e6b0abd77890b2e5eb49089523c4d2124adc4c7f794dded231301490377R855-R863) [[7]](diffhunk://#diff-6ee521e8ffd685a4efd04867b49c2b10aeb63a51024b5ecb6d71a6899a829019R14-R21) [[8]](diffhunk://#diff-dcdf7e5e2edce027910cff5c1ec4c0727d97fbaff84b295f6e576755f696e723L139-R158)

**Entity attribute consistency and improvements:**

* Standardized the inclusion of integration and purpose attributes across all entity types by introducing and using a `build_state_attributes` helper method, improving attribute consistency and discoverability. [[1]](diffhunk://#diff-326976f361d8e8ddf85a24e0cc81be575c557e8959b30504531d2341de3e615fR8) [[2]](diffhunk://#diff-326976f361d8e8ddf85a24e0cc81be575c557e8959b30504531d2341de3e615fR86-R97) [[3]](diffhunk://#diff-a6b2ba2d4f3fc1d449bd0506cc965e16b8dd7cd7be07a4a43d016714d93af3e6L17-R17) [[4]](diffhunk://#diff-a6b2ba2d4f3fc1d449bd0506cc965e16b8dd7cd7be07a4a43d016714d93af3e6R28) [[5]](diffhunk://#diff-a6b2ba2d4f3fc1d449bd0506cc965e16b8dd7cd7be07a4a43d016714d93af3e6R90-R96) [[6]](diffhunk://#diff-a6b2ba2d4f3fc1d449bd0506cc965e16b8dd7cd7be07a4a43d016714d93af3e6L182-R190) [[7]](diffhunk://#diff-3bef21a58244e59f349335aebaf15d2e1526b01e0984781c71c70b7fd64d75eaL15) [[8]](diffhunk://#diff-3bef21a58244e59f349335aebaf15d2e1526b01e0984781c71c70b7fd64d75eaL107-R106) [[9]](diffhunk://#diff-3bef21a58244e59f349335aebaf15d2e1526b01e0984781c71c70b7fd64d75eaL263-R264) [[10]](diffhunk://#diff-01212244df537a544a7b250ac2d197b4343bd6a1a44ce706fb65615f2d5dba54L17) [[11]](diffhunk://#diff-01212244df537a544a7b250ac2d197b4343bd6a1a44ce706fb65615f2d5dba54L103-R102) [[12]](diffhunk://#diff-01212244df537a544a7b250ac2d197b4343bd6a1a44ce706fb65615f2d5dba54L211-R210) [[13]](diffhunk://#diff-b27fd0171879bb12c6b7980f4022c6c60ff74766205d2eefd0bdd2fa1422a75fR14) [[14]](diffhunk://#diff-b27fd0171879bb12c6b7980f4022c6c60ff74766205d2eefd0bdd2fa1422a75fR52-R56)

**Switch and button entity improvements:**

* Updated the rule switch entity to expose new attributes (`applies_to`, `applies_to_kind`, `category`) for matched rules, providing more context for automations and UI. [[1]](diffhunk://#diff-dcdf7e5e2edce027910cff5c1ec4c0727d97fbaff84b295f6e576755f696e723L139-R158) [[2]](diffhunk://#diff-6ee521e8ffd685a4efd04867b49c2b10aeb63a51024b5ecb6d71a6899a829019R14-R21)
* Added a new translation key and extra state attributes for the runtime sync button entity, improving its metadata and clarity. [[1]](diffhunk://#diff-b27fd0171879bb12c6b7980f4022c6c60ff74766205d2eefd0bdd2fa1422a75fR14) [[2]](diffhunk://#diff-b27fd0171879bb12c6b7980f4022c6c60ff74766205d2eefd0bdd2fa1422a75fR52-R56) [[3]](diffhunk://#diff-6ee521e8ffd685a4efd04867b49c2b10aeb63a51024b5ecb6d71a6899a829019R364)

**Internal code and model updates:**

* Extended the `FirewallaPolicyRule` model to include `applies_to_kind` and `category` fields, supporting the new metadata throughout the codebase.
* Refactored internal methods to support the extraction and normalization of new metadata fields. [[1]](diffhunk://#diff-6f0f34e6f7600b33fac3b655d201469cba2422831c28567427d89eb66718c862R1167-R1199) [[2]](diffhunk://#diff-6f0f34e6f7600b33fac3b655d201469cba2422831c28567427d89eb66718c862L1745-R1801) [[3]](diffhunk://#diff-6f0f34e6f7600b33fac3b655d201469cba2422831c28567427d89eb66718c862L1774-R1824) [[4]](diffhunk://#diff-6f0f34e6f7600b33fac3b655d201469cba2422831c28567427d89eb66718c862L1821-R1864)

**Translation and constant additions:**

* Added new translation and attribute constants to support the new entity attributes and purposes. [[1]](diffhunk://#diff-6ee521e8ffd685a4efd04867b49c2b10aeb63a51024b5ecb6d71a6899a829019R14-R21) [[2]](diffhunk://#diff-6ee521e8ffd685a4efd04867b49c2b10aeb63a51024b5ecb6d71a6899a829019R364) [[3]](diffhunk://#diff-dcdf7e5e2edce027910cff5c1ec4c0727d97fbaff84b295f6e576755f696e723R14-R16)

These changes collectively improve the integration's ability to provide richer, more structured information about policy rules and entities, making it easier to create automations and understand the context of each entity within Home Assistant.What changed:
- add `applies_to`, `applies_to_kind`, and best-effort `category` attributes to rule switch entities
- align rule applicability kind with the displayed Home Assistant-facing identity, including reporting affiliated-user rewrites as `user`
- add a shared `integration` attribute and clearer `purpose` metadata across switches, sensors, binary sensors, device trackers, and buttons
- improve runtime sync button metadata and expand translations for the new attributes and labels
- document the user-facing identity decision across architecture, standards, rule model, and reverse-engineering guidance

Why:
- make Firewalla rule entities easier to understand in Home Assistant by exposing who a rule applies to and what type of target it uses
- standardize entity metadata across the integration and keep applicability semantics consistent with the identities we intentionally present to users

## Summary

Describe what changed and why.

## Validation

- [ ] `bash ./utils/quick_lint.sh`
- [ ] `python -m mypy custom_components/firewalla_local`
- [ ] `python -m pytest tests/ -v`

List any focused validation you ran and any intentionally skipped checks.

## Release summary

If this change is user-visible, add a short plain-language summary suitable for release notes.

## Docs impact

- [ ] No user-facing docs needed
- [ ] README updated
- [ ] User guide updated
- [ ] Contributor or support docs updated

## Issue linkage

Closes #