### PR TITLE
Document complete pairing protocol and enhance capture tool

### DIFF
--- a/custom_components/firewalla_local/device_tracker.py
+++ b/custom_components/firewalla_local/device_tracker.py
@@ -51,7 +51,8 @@ async def async_setup_entry(
 
 
 class FirewallaDeviceTracker(
-    CoordinatorEntity[FirewallaDataUpdateCoordinator], ScannerEntity
+    CoordinatorEntity[FirewallaDataUpdateCoordinator],
+    ScannerEntity,  # type: ignore[misc]  # ScannerEntity type varies by HA version
 ):
     """Expose one selected Firewalla host as a router-backed device tracker."""
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -95,9 +95,17 @@ The repository assumes the following protocol facts:
 
 - first-time pairing begins from the Firewalla QR JSON payload
 - provisioning uses the required cloud-assisted bootstrap sequence
-- local runtime communication uses encrypted HTTP POST requests to `http://{local_ip}:8833/v1/encipher/message/{gid}`
-- local runtime credentials include `gid`, `eid`, `aid`, and the decrypted symmetric key
-- key generation and signing require SPKI public PEM and PKCS#8 private PEM handling
+
+  *(The full pairing protocol from QR through cloud login, rendezvous, group
+  polling, and symmetric key decryption is documented in
+  `docs/REVERSE_ENGINEERING_WORKFLOW.md#pairing-protocol-full-sequence`.)*
+
+- local runtime communication uses encrypted HTTP POST requests to
+  `http://{local_ip}:8833/v1/encipher/message/{gid}`
+- local runtime credentials include `gid`, `eid`, `aid`, and the decrypted
+  symmetric key
+- key generation and signing require SPKI public PEM and PKCS#8 private PEM
+  handling
 
 Transport questions and mutation-surface questions are separate concerns. Unverified mutation details do not justify weakening the protocol boundary.
 

--- a/docs/REVERSE_ENGINEERING_WORKFLOW.md
+++ b/docs/REVERSE_ENGINEERING_WORKFLOW.md
@@ -67,6 +67,13 @@ by whichever local fields were easiest to capture first.
 
 This workflow covers:
 
+- the full first-time pairing protocol (QR → cloud → local runtime)
+
+  *(This was the most critical reverse-engineering finding. The pairing
+  protocol is not published by Firewalla and was discovered entirely through
+  live capture and trial. Do not treat it as a prerequisite — it is preserved
+  here because nowhere else in the repo documents it end-to-end.)*
+
 - reuse of a working Home Assistant config entry for live local protocol access
 - direct runtime pulls for current-value comparison without re-pairing
 - runtime inventory capture before and after user actions
@@ -74,8 +81,259 @@ This workflow covers:
 - decryption and inspection of local port `8833` traffic
 - comparison of mutation payloads across rule families
 
-This workflow does not cover first-time pairing design in detail. Pairing is
-already documented elsewhere and treated here as a prerequisite.
+## Pairing protocol (full sequence)
+
+This section documents the reverse-engineered pairing protocol end-to-end. It
+is the most critical finding in this repository. Without it, there is no
+integration.
+
+### What the QR code contains
+
+The Firewalla box displays a QR code on its screen containing JSON with these
+fields:
+
+| Field | Type | Example | Purpose |
+| --- | --- | --- | --- |
+| `gid` | string | `e4734492-...` | Group ID identifying the box |
+| `license` | string | `b56208b3-...` | Device license key |
+| `seed` | string | `rev4872430275...` | Random seed for pre-pairing crypto |
+| `ek` | string | `9DAKEbaxhP7M...` | Encrypted pairing code (base64) |
+| `ipaddress` | string | `23.245.207.179` | Public WAN IP |
+| `model` | string | `gold` | Box model |
+| `type` | string | `fb` | Always `fb` |
+| `deviceName` | string | `Firewalla` | Box display name |
+| `licensemode` | string | `1` | License mode |
+| `rr` | string | `e767` | Short rendezvous reference |
+
+Reference: `.artifacts/poc/20260323-174620/qr.json`
+
+### Step 1 — Decrypt the QR pairing code
+
+The `ek` field is AES-256-CBC encrypted with IV = 16 zero bytes. The
+encryption key is derived from the QR data:
+
+```
+bootstrap_key = license[:8] + seed
+plaintext = AES-256-CBC-decrypt(ek, bootstrap_key, iv=0..0)
+```
+
+The decrypted plaintext reveals a rendezvous object:
+
+```json
+{"r": "e7679e89-...", "evalue": {"license": "b56208b3-..."}}
+```
+
+The `r` value is the rendezvous ID (`rid`). The `evalue` is the license
+assertion that will be sent to the Firewalla cloud.
+
+Reference: `.artifacts/poc/20260323-174620/pairing_code.json`
+
+### Step 2 — Generate an RSA keypair
+
+Generate a 2048-bit RSA keypair formatted for Firewalla ETP:
+
+- public key: SPKI PEM (`SubjectPublicKeyInfo`)
+- private key: PKCS#8 PEM
+
+The private key never leaves the client. The public key is sent to the cloud.
+
+Code reference: `api/crypto.py::generate_firewalla_keys()`
+
+### Step 3 — Cloud login (`POST /login/eptoken`)
+
+Send to `https://firewalla.encipher.io/app/api/v2/login/eptoken`:
+
+```json
+{
+  "assertion": {
+    "name": "<device name>",
+    "info": {"name": "circle"},
+    "publicKey": "<SPKI public PEM>",
+    "appId": "com.rottiesoft.circle",
+    "appSecret": "fbb05afa-...",
+    "signature": ""
+  }
+}
+```
+
+The response contains:
+
+| Field | Purpose |
+| --- | --- |
+| `access_token` | Bearer token for subsequent cloud API calls |
+| `eid` | Encryption endpoint ID (identifies this pairing session) |
+| `aid` | Account ID (the provisioning identity on the cloud side) |
+| `groups` | Group records (initially empty) |
+
+The `appId` and `appSecret` constants were determined by capturing the
+Firewalla mobile app's cloud traffic. They are the same values the official
+app uses.
+
+Code reference: `api/auth.py::build_login_payload()`
+
+### Step 4 — Cloud rendezvous (`POST /ept/rendezvous/me`)
+
+Use the access token to link this pairing to the box:
+
+```json
+{
+  "rid": "<rendezvous_id from QR>",
+  "evalue": "{\"license\":\"<license>\"}"
+}
+```
+
+The `evalue` must be compact JSON (no whitespace), matching the NodeJS
+`JSON.stringify` serialization.
+
+This tells the Firewalla cloud "this client is pairing with box X". The cloud
+relays the rendezvous, and the Firewalla box generates a symmetric key for
+local communication, storing it in a cloud group record under the client's
+identity.
+
+Code reference: `api/auth.py::build_cloud_link_payload()`
+
+### Step 5 — Poll for the group record
+
+The box does not return the symmetric key immediately. The integration polls
+the cloud endpoints in this order:
+
+1. `GET /ept/group/me` — first candidate endpoint
+2. `GET /ept/groups/me` — second candidate endpoint
+3. `POST /login/eptoken` — fallback if neither group endpoint returned data;
+   this refreshes the cloud identity and the fresh response includes a
+   `groups` array
+
+The first two are GET requests using the existing access token. The third is
+a full POST re-login that produces a new identity with candidate groups.
+Steps 1-2 are repeated across multiple poll attempts with a 3-second
+interval between attempts.
+
+The group record contains `symmetricKeys`, an array of RSA-encrypted
+symmetric key objects. Each object has a `key` field that is the symmetric
+key material encrypted with the public key sent in Step 3. The matching
+group is identified by comparing the group `_id` field against the QR
+`gid`.
+
+### Step 6 — Decrypt the symmetric key
+
+Decrypt the `key` field with the RSA private key:
+
+```
+symmetric_key_plain = RSA-decrypt(symmetric_key_cipher, private_pem)
+```
+
+This yields the 32-byte raw AES key material used for all subsequent local
+communication. The first 32 UTF-8 bytes of this material form the AES-256
+key.
+
+### Summary of what you get out of pairing
+
+| Credential | Source | Purpose |
+| --- | --- | --- |
+| `gid` | QR code | Identifies the box group for local endpoints |
+| `eid` | Cloud login response | Identifies this pairing session |
+| `aid` | Cloud login response | Account ID |
+| `host` | User-supplied IP or `fire.walla` | Where to reach the box |
+| `license` | QR code | Device license (stored for reauth) |
+| `symmetric_key` | RSA-decrypted from group record | AES-256 key for local traffic |
+
+These six values are stored in the Home Assistant config entry and are all
+that is needed for local runtime access. Pairing is never repeated unless the
+entry is removed.
+
+Reference: `.artifacts/poc/20260323-174620/bootstrap.json`
+Reference: `.artifacts/poc/20260323-174620/identity.json`
+
+### Crypto chain summary
+
+```
+QR ek ──AES-256-CBC──> rendezvous ID
+       key = license[:8] + seed
+       iv  = 16 zero bytes
+
+Cloud login ──> access_token + eid + aid
+Cloud rendezvous ──> box generates symmetric key, stores in cloud group
+Group poll ──> RSA-encrypted symmetric key
+RSA decrypt (2048-bit private key) ──> raw symmetric key material
+
+Every local POST:
+  build Firewalla envelope (mtype + message with from/obj/appInfo)
+  json.dumps(envelope, separators=(",", ":")) ──> AES-256-CBC(key) ──> base64
+  payload = {"message": base64_ciphertext, "timestamp": <now>}
+  POST http://{host}:8833/v1/encipher/message/{gid}
+```
+
+### POC artifacts
+
+The repository preserves three successive successful pairing runs under
+`.artifacts/poc/`:
+
+- `20260323-174620` — First successful full pairing
+- `20260323-175103` — Second run (timing test)
+- `20260323-175408` — Third run (full validation)
+
+Each directory contains the complete artifact set:
+
+| File | Contains |
+| --- | --- |
+| `qr.json` | Raw QR data from the box screen |
+| `pairing_code.json` | Decrypted QR `ek` → rendezvous ID and license evalue |
+| `bootstrap.json` | Cloud login results (aid, eid, gid, encrypted symmetric key) |
+| `identity.json` | Final provisioning identity (aid, eid) |
+| `cloud_link_response.txt` | Cloud rendezvous response confirming the link |
+| `group_fetch.json` | Group record polling metadata |
+| `local_init_message.json` | The encrypted init request sent to the box |
+| `local_payload.json` | The raw encrypted local response |
+| `local_response_decrypted.json` | Decrypted init response — the full runtime payload |
+| `local_response.txt` | Raw HTTP response text |
+| `summary.json` | End-to-end success for cloud + local steps |
+
+### Live pairing in the integration code
+
+The pairing protocol is implemented in:
+
+- `api/auth.py` — Cloud provisioning helpers (`async_provision_firewalla_credentials`)
+- `api/crypto.py` — Key generation, AES encryption, RSA encryption
+- `config_flow.py` — Home Assistant config flow that calls the provisioning
+  helpers
+
+### Confirmed identity values
+
+The captured iPhone pairing request revealed the outer HTTP fingerprint and
+inner appInfo identity used by the official app. These are documented for
+reference because they confirm the protocol family, not because the
+integration should impersonate them.
+
+Captured iPhone init request (from
+`.captures/pairing_other_device_8833.pcap`, decrypted via
+`utils/analyze_capture.py`):
+
+```
+Outer HTTP headers:
+  User-Agent: Firewalla/89 CFNetwork/3860.400.51 Darwin/25.3.0
+  Accept: application/json
+  Accept-Language: en-US,en;q=0.9
+
+Outer envelope fields:
+  from:       iPhone
+
+Inner appInfo:
+  appID:      com.rottiesoft.circle
+  deviceName: iPhone
+  platform:   ios
+  timezone:   America/New_York
+  version:    1.68-89
+  language:   en
+  eid:        X4fp-7w651edXhvxCX53tg
+  ios:        26.3-1
+```
+
+The integration uses the same `appID` (`com.rottiesoft.circle`) but identifies
+itself transparently as the integration rather than as an iPhone. This was an
+intentional design choice: spoofing the exact iPhone identity would be brittle
+(maintenance cost on version changes), would not prevent backend blocking on
+its own, and creates a sharper failure mode if the vendor ever inspects
+traffic.
 
 ## Preconditions
 

--- a/docs/REVERSE_ENGINEERING_WORKFLOW.md
+++ b/docs/REVERSE_ENGINEERING_WORKFLOW.md
@@ -87,6 +87,27 @@ This section documents the reverse-engineered pairing protocol end-to-end. It
 is the most critical finding in this repository. Without it, there is no
 integration.
 
+> **Critical timeline fact — read this first**
+>
+> The pairing protocol works identically for **every client** (iPhone, Home
+> Assistant, etc.). The symmetric key it produces is **per-box, not per-client**.
+> All clients that pair with the same box receive the same AES key.
+>
+> We did not need the iPhone's symmetric key. The actual order of events was:
+>
+> 1. **We paired ourselves first.** We scanned the box's QR code, ran the
+>    cloud provisioning flow (Steps 1–6 below), and obtained **our own**
+>    `symmetric_key`. The proof is in `.artifacts/poc/20260323-174620/`.
+> 2. **We captured the iPhone separately.** While the iPhone performed
+>    actions, we SSH'd into the box and ran `tcpdump` on port 8833.
+> 3. **We decrypted the iPhone's traffic with our key.** Because the key is
+>    box-level, the same AES material that our integration uses also decrypts
+>    every other client's traffic to that box.
+>
+> This is why `utils/analyze_capture.py` can decrypt any pcap from your
+> paired box without re-pairing — it loads *your* key from the Home Assistant
+> config entry, and that key works for all traffic to that box.
+
 ### What the QR code contains
 
 The Firewalla box displays a QR code on its screen containing JSON with these
@@ -214,6 +235,12 @@ key material encrypted with the public key sent in Step 3. The matching
 group is identified by comparing the group `_id` field against the QR
 `gid`.
 
+**Key fact: this symmetric key is per-box.** Every client (iPhone, Home
+Assistant, etc.) that successfully pairs with this box receives the same
+AES key material. This is why `utils/analyze_capture.py` can decrypt
+any client's traffic using the key stored in the Home Assistant config
+entry — the phone and HA share the same box-level key.
+
 ### Step 6 — Decrypt the symmetric key
 
 Decrypt the `key` field with the RSA private key:
@@ -327,6 +354,12 @@ Inner appInfo:
   eid:        X4fp-7w651edXhvxCX53tg
   ios:        26.3-1
 ```
+
+**How we decoded this:** We paired our own Home Assistant integration first
+(Steps 1–6 above), which gave us the box-level symmetric key. Then we
+captured the iPhone's traffic via remote `tcpdump` on the Firewalla box and
+decrypted it using `utils/analyze_capture.py` with *our* key. Because the
+symmetric key is per-box, it worked.
 
 The integration uses the same `appID` (`com.rottiesoft.circle`) but identifies
 itself transparently as the integration rather than as an iPhone. This was an

--- a/tools/support/WINDOWS_PACKET_CAPTURE_USAGE.md
+++ b/tools/support/WINDOWS_PACKET_CAPTURE_USAGE.md
@@ -8,71 +8,99 @@ Copy these three files into the same folder on the Windows machine:
 
 Then open Command Prompt in that folder and run one capture command at a time.
 
-Before you worry about packet capture, first update to the latest Firewalla
-Local build and try pairing again. The pairing process was reworked to match
-the native Firewalla app flow more closely, and many users should not need a
-capture after updating.
+## Quick start — one capture, key, and decoded analysis
 
-Recommended troubleshooting workflow:
+This workflow captures a phone pairing, saves the box-level symmetric key, and
+produces a shareable redacted report of the decrypted message structure.
 
-1. Update to the latest Firewalla Local build and try pairing again first.
-2. If pairing still fails, capture one successful phone pairing in the same
-  environment.
-3. Capture one Home Assistant pairing attempt from the updated integration.
-4. Copy the relevant Home Assistant pairing log lines from that Home Assistant
-  attempt.
-5. Share the two safe report zip files and the Home Assistant log lines.
-6. Keep the raw `.pcap` files private unless you are explicitly asked to share
-  them privately.
+**Before you start:** Enable SSH Console in your Firewalla mobile app
+(Settings > Advanced > Configurations > SSH Console) and note the password.
 
-For most users, the full capture workflow should take around 10 minutes.
-The safe report zip is generated locally on your side so you can share the
-comparison data without uploading the raw packet capture by default.
+### Step 1 — Save the QR JSON to a file
 
-Recommended successful phone capture:
+Open the Firewalla app on your phone. Go to Settings > Advanced > Allow
+Additional Pairing. A QR code appears. Use your phone's text recognition to
+copy the raw JSON content and save it to a file named `qr.txt` in the capture
+folder.
+
+### Step 2 — Start the capture
+
+Open Command Prompt in the capture folder and run:
 
 ```bat
-run_capture_firewalla_packets.bat --host fire.walla --label phone-success
+run_capture_firewalla_packets.bat --host fire.walla --label phone --client-ip <phone-ip> --qr-file qr.txt --email 'your@email.com'
 ```
 
-Recommended Home Assistant capture:
+Replace `<phone-ip>` with your phone's IP address on your local network.
+
+The script will:
+1. Ask for the Firewalla SSH password
+2. Run cloud provisioning to obtain the box-level symmetric key (saves as `.key`)
+3. Start tcpdump on the Firewalla box
+4. Wait for you to perform the pairing
+
+### Step 3 — Generate a fresh QR and pair your phone
+
+The QR code used for provisioning is now consumed. While the capture is
+running and waiting, generate a **fresh** QR code:
+
+1. Toggle "Allow Additional Pairing" OFF, then ON again in the Firewalla app
+2. Scan the new QR code with your phone to complete the pairing
+3. The phone's traffic is now being captured
+
+### Step 4 — Stop the capture
+
+After the phone finishes pairing, press **Enter** in the Command Prompt window.
+The script stops tcpdump, downloads the pcap, and creates:
+- `firewalla_capture_...pcap` — the raw network capture
+- `provisioning_key_....key` — the symmetric key (can decrypt this pcap)
+- Safe report zip — HTTP metadata only, no decrypted content
+
+### Step 5 — Decode and inspect the phone's messages
+
+Decrypt the pcap using the saved key to see what the phone sent:
 
 ```bat
-run_capture_firewalla_packets.bat --host fire.walla --label home-assistant-attempt
+python capture_firewalla_packets.py --decode firewalla_capture_...pcap --key-file provisioning_key_....key
 ```
 
-If you know the client IP for the device involved in the capture, include it to
-reduce noise.
+This prints every decrypted HTTP request and response — the full message
+structure the phone used during pairing.
 
-Example successful phone capture with a phone IP filter:
+### Step 6 — Share a redacted report (no sensitive data)
+
+To share the analysis without exposing credential values:
 
 ```bat
-run_capture_firewalla_packets.bat --host fire.walla --label phone-success --client-ip 192.168.202.173
+python capture_firewalla_packets.py --decode firewalla_capture_...pcap --key-file provisioning_key_....key --redacted-report analysis.json
 ```
 
-If `fire.walla` does not resolve correctly in that environment, use the router IP
-address instead:
+This replaces credential fields (`eid`, `aid`, `gid`, tokens, UUIDs) with
+`<redacted>` while preserving the full message structure. Share the
+`analysis.json` file — no keys, IPs, or network metadata included.
+
+---
+
+## Alternative: basic troubleshooting with safe reports only
+
+If you only need to share HTTP-level metadata (request counts, response status
+codes, content lengths) without decrypting payloads, you can skip the QR
+provisioning step and use `--client-ip` only:
 
 ```bat
-run_capture_firewalla_packets.bat --host 192.168.202.1 --label phone-success
+run_capture_firewalla_packets.bat --host fire.walla --label phone --client-ip 192.168.202.173
 ```
 
-Example Home Assistant capture with a Home Assistant IP filter:
+This produces a safe report zip with HTTP metadata and TCP events, but no key
+file. The raw pcap stays on your machine.
 
-```bat
-run_capture_firewalla_packets.bat --host fire.walla --label home-assistant-attempt --client-ip 192.168.202.220
-```
+---
 
-You can also use a router IP in the same command:
-
-```bat
-run_capture_firewalla_packets.bat --host 192.168.202.1 --label home-assistant-attempt --client-ip 192.168.202.220
-```
-
-What the batch file does:
+## What the batch file does
 
 - creates a local virtual environment in `.venv_firewalla_capture`
-- installs `paramiko`, `scp`, and `scapy`
+- installs `paramiko`, `scp`, `scapy`, `aiohttp`, and `cryptography`
+- optionally runs cloud provisioning to capture the symmetric key
 - runs the Windows Firewalla packet capture helper
 - builds a local safe report zip from cleartext HTTP metadata and TCP lifecycle
   events
@@ -80,30 +108,33 @@ What the batch file does:
 The capture file is saved in the folder where the batch file is running, with a
 name like `firewalla_capture_YYYYMMDD-HHMMSS.pcap`.
 
+The provisioning key file (when `--qr-file` is used) is saved alongside the
+pcap with a name like `provisioning_key_YYYYMMDD_HHMMSS.key`. Keep this file
+private — it can decrypt the pcap. Only share it with the raw pcap privately.
+
 The safe report zip is saved in the same folder, with a name like
 `firewalla_capture_YYYYMMDD-HHMMSS_phone-success_safe_report.zip`.
 
-Notes:
+---
+
+## Notes
 
 - The SSH username is hardcoded as `pi`
 - The SSH port is hardcoded as `22`
 - You will be prompted for the SSH password
 - `--host` can be either `fire.walla` or the Firewalla box IP address
-- `--label` is optional but recommended so the output files clearly identify the
-  successful phone capture versus the Home Assistant capture
+- `--label` is optional but recommended so output files clearly identify the
+  capture purpose
 - `--client-ip` is optional and limits the remote `tcpdump` to the client IP
   you want to monitor
-- When pairing from the Firewalla mobile app, `--client-ip` should be the phone
-  IP address of the device doing the pairing
-- When monitoring Home Assistant traffic instead, `--client-ip` should be the
-  IP address of the Home Assistant instance
-- The helper currently captures `tcp port 8833`, optionally narrowed to one
-  client IP
+- Use `--qr-file` instead of `--qr-json` on Windows to avoid shell quoting
+  issues with the JSON payload
+- The provisioning step consumes the QR code — generate a fresh one for the
+  actual phone pairing (Step 3)
+- The symmetric key is per-box, not per-client. The key from any provisioning
+  session decrypts all traffic to that box
 - The safe report includes cleartext metadata such as request lines, response
   status lines, selected headers like `User-Agent`, content lengths, and TCP
   disconnect events
-- The safe report also summarizes connection reuse, request method order,
-  response status order, repeated `412` responses, and whether live-stream
-  traffic was observed
 - The safe report does not decrypt payloads and does not include the raw `.pcap`
 - The raw `.pcap` may contain sensitive device and network information

--- a/tools/support/capture_firewalla_packets.py
+++ b/tools/support/capture_firewalla_packets.py
@@ -3,19 +3,25 @@
 This support tool is intentionally narrow:
 
 - prompt for router IP address or hostname and SSH password
+- optionally, accept QR JSON and email for cloud provisioning
 - SSH to the Firewalla box as user ``pi`` on port ``22``
 - start a remote tcpdump capture in the background
 - wait for the user to reproduce the behavior they want to capture
 - stop the capture, download the pcap, and clean up remote files
 - build a local safe report from cleartext HTTP metadata only
+- when provisioning was used, write a sidecar key file alongside the pcap
+  so the capture can be decrypted later
 
-It does not perform any payload decryption and does not include the raw pcap in
-the safe report archive.
+It does not include the raw pcap or key in the safe report archive.
 """
+
+# pylint: disable=too-many-lines
 
 from __future__ import annotations
 
 import argparse
+import asyncio
+import base64
 import getpass
 import ipaddress
 import json
@@ -28,7 +34,7 @@ from contextlib import suppress
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Any, Final
 
 try:
     import paramiko
@@ -49,9 +55,35 @@ except ImportError:  # pragma: no cover - environment-specific dependency
     TCP = None
     rdpcap = None
 
+try:
+    import aiohttp
+except ImportError:  # pragma: no cover - environment-specific dependency
+    aiohttp = None
+
+try:
+    from cryptography.hazmat.primitives import hashes, padding, serialization
+    from cryptography.hazmat.primitives.asymmetric import padding as asym_padding
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+    CRYPTOGRAPHY_AVAILABLE = True
+except ImportError:  # pragma: no cover - environment-specific dependency
+    CRYPTOGRAPHY_AVAILABLE = False
+
 if TYPE_CHECKING:
     from paramiko import SSHClient
 
+
+PROVISIONING_APP_API_BASE: Final = "https://firewalla.encipher.io/app/api/v2"
+PROVISIONING_APP_ID: Final = "com.rottiesoft.circle"
+PROVISIONING_APP_SECRET: Final = "fbb05afa-9145-41f1-8076-9de8be56f104"
+PROVISIONING_GROUP_POLL_ATTEMPTS: Final = 20
+PROVISIONING_GROUP_POLL_INTERVAL: Final = 3.0
+PROVISIONING_REQUEST_TIMEOUT: Final = 15.0
+PROVISIONING_REQUIRED_QR_FIELDS: Final = ("gid", "seed", "license", "ek", "ipaddress")
+PROVISIONING_ENDPOINT_LOGIN: Final = "/login/eptoken"
+PROVISIONING_ENDPOINT_RENDEZVOUS: Final = "/ept/rendezvous/me"
+PROVISIONING_ENDPOINT_GROUP_CANDIDATES: Final = ("/ept/group/me", "/ept/groups/me")
 
 SSH_PORT: Final = 22
 SSH_USER: Final = "pi"
@@ -80,6 +112,7 @@ class HttpMessage:
     first_line: str
     headers: dict[str, str]
     content_length: int
+    body: bytes = b""
 
 
 @dataclass(slots=True)
@@ -96,6 +129,299 @@ class SafeReportEvent:
     content_type: str | None = None
     latency_seconds: float | None = None
     status_code: str | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class _ProvisioningQrData:
+    """Validated QR fields needed for cloud provisioning."""
+
+    gid: str
+    seed: str
+    license: str
+    ek: str
+    ipaddress: str
+
+    @classmethod
+    def from_raw_json(cls, raw_json: str) -> _ProvisioningQrData:
+        """Parse and validate raw QR JSON."""
+        try:
+            payload = json.loads(raw_json)
+        except json.JSONDecodeError as err:
+            raise ValueError("QR JSON is not valid JSON") from err
+        if not isinstance(payload, dict):
+            raise ValueError("QR JSON root must be an object")
+        missing = [f for f in PROVISIONING_REQUIRED_QR_FIELDS if f not in payload]
+        if missing:
+            raise ValueError(f"QR JSON missing required fields: {', '.join(missing)}")
+        normalized: dict[str, str] = {}
+        for field in PROVISIONING_REQUIRED_QR_FIELDS:
+            value = payload[field]
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"QR field {field!r} must be a non-empty string")
+            normalized[field] = value.strip()
+        return cls(
+            gid=normalized["gid"],
+            seed=normalized["seed"],
+            license=normalized["license"],
+            ek=normalized["ek"],
+            ipaddress=normalized["ipaddress"],
+        )
+
+
+@dataclass(slots=True, frozen=True)
+class _ProvisioningResult:
+    """Result of one cloud provisioning run."""
+
+    symmetric_key: str
+    gid: str
+    eid: str
+    aid: str
+
+
+def _derive_qr_key(license_value: str, seed: str) -> str:
+    """Derive the pre-pairing AES key material from QR fields."""
+    return f"{license_value[:8]}{seed}"
+
+
+def _derive_aes256_key(key_material: str) -> bytes:
+    """Derive AES-256 key matching NodeJS SecureUtil behavior."""
+    key = key_material[:32].encode("utf-8")
+    if len(key) != 32:
+        raise ValueError(
+            "Derived AES key material must be at least 32 UTF-8 bytes long"
+        )
+    return key
+
+
+def _aes256_cbc_decrypt_from_base64(ciphertext: str, key_material: str) -> str:
+    """Decrypt a base64 AES-256-CBC payload."""
+    key = _derive_aes256_key(key_material)
+    iv = bytes(16)
+    cipher = Cipher(algorithms.AES(key), modes.CBC(iv))
+    decryptor = cipher.decryptor()
+    padded = decryptor.update(base64.b64decode(ciphertext)) + decryptor.finalize()
+    unpadder = padding.PKCS7(algorithms.AES.block_size).unpadder()
+    return (unpadder.update(padded) + unpadder.finalize()).decode("utf-8")
+
+
+def _generate_firewalla_keys() -> tuple[str, str]:
+    """Generate RSA keypair and return (private_pem, public_pem)."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    public_pem = (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+    )
+    return private_pem, public_pem
+
+
+def _rsa_decrypt_base64(ciphertext: str, private_pem: str) -> str:
+    """Decrypt base64 RSA ciphertext using OAEP/SHA-1."""
+    private_key = serialization.load_pem_private_key(
+        private_pem.encode("utf-8"), password=None
+    )
+    plaintext = private_key.decrypt(
+        base64.b64decode(ciphertext),
+        asym_padding.OAEP(
+            mgf=asym_padding.MGF1(algorithm=hashes.SHA1()),
+            algorithm=hashes.SHA1(),
+            label=None,
+        ),
+    )
+    return plaintext.decode("utf-8")
+
+
+def _decrypt_pairing_code(qr_data: _ProvisioningQrData) -> dict[str, object]:
+    """Decrypt the QR ek field and return the pairing rendezvous data."""
+    plaintext = _aes256_cbc_decrypt_from_base64(
+        qr_data.ek,
+        _derive_qr_key(qr_data.license, qr_data.seed),
+    )
+    try:
+        parsed = json.loads(plaintext)
+    except json.JSONDecodeError:
+        return {"r": plaintext, "evalue": {"license": qr_data.license}}
+    if not isinstance(parsed, dict):
+        raise ValueError("QR pairing payload did not decode to an object")
+    return parsed
+
+
+async def _provision_symmetric_key(
+    qr_data: _ProvisioningQrData,
+    private_pem: str,
+    public_pem: str,
+    email: str,
+) -> _ProvisioningResult:
+    """Run the cloud provisioning flow and return the symmetric key."""
+    pairing_code = _decrypt_pairing_code(qr_data)
+    rendezvous_id = pairing_code.get("r") or pairing_code.get("rid")
+    evalue = pairing_code.get("evalue")
+    if not isinstance(rendezvous_id, str) or not isinstance(evalue, dict):
+        raise ValueError("QR pairing code missing rendezvous data")
+
+    timeout = aiohttp.ClientTimeout(total=PROVISIONING_REQUEST_TIMEOUT)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        # Step 1: login/eptoken
+        login_payload = {
+            "assertion": {
+                "name": email,
+                "info": {"name": "circle"},
+                "publicKey": public_pem,
+                "appId": PROVISIONING_APP_ID,
+                "appSecret": PROVISIONING_APP_SECRET,
+                "signature": "",
+            }
+        }
+        async with session.post(
+            f"{PROVISIONING_APP_API_BASE}{PROVISIONING_ENDPOINT_LOGIN}",
+            json=login_payload,
+            headers={"Content-Type": "application/json"},
+        ) as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"login/eptoken returned HTTP {resp.status}")
+            login_data: dict[str, object] = await resp.json()
+        access_token = login_data.get("access_token")
+        eid = login_data.get("eid")
+        aid = login_data.get("aid")
+        if not isinstance(access_token, str) or not access_token:
+            raise RuntimeError("login/eptoken response missing access_token")
+        if not isinstance(eid, str) or not eid:
+            raise RuntimeError("login/eptoken response missing eid")
+        if not isinstance(aid, str) or not aid:
+            raise RuntimeError("login/eptoken response missing aid")
+
+        # Step 2: cloud rendezvous link
+        rendezvous_payload = {
+            "rid": rendezvous_id,
+            "evalue": json.dumps(evalue, separators=(",", ":")),
+        }
+        async with session.post(
+            f"{PROVISIONING_APP_API_BASE}{PROVISIONING_ENDPOINT_RENDEZVOUS}",
+            json=rendezvous_payload,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {access_token}",
+            },
+        ) as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"Cloud rendezvous returned HTTP {resp.status}")
+
+        # Step 3: poll for group with symmetric key
+        gid = qr_data.gid
+        current_access_token: str = access_token
+        for attempt in range(PROVISIONING_GROUP_POLL_ATTEMPTS):
+            if attempt:
+                await asyncio.sleep(PROVISIONING_GROUP_POLL_INTERVAL)
+
+            for endpoint in PROVISIONING_ENDPOINT_GROUP_CANDIDATES:
+                async with session.get(
+                    f"{PROVISIONING_APP_API_BASE}{endpoint}",
+                    headers={"Authorization": f"Bearer {current_access_token}"},
+                ) as resp:
+                    if resp.status == 401:
+                        break
+                    if resp.status != 200:
+                        continue
+                    groups_data: object = await resp.json()
+
+                groups: list[dict[str, Any]] = []
+                if isinstance(groups_data, list):
+                    groups = [g for g in groups_data if isinstance(g, dict)]
+                elif isinstance(groups_data, dict):
+                    raw = groups_data.get("groups")
+                    if isinstance(raw, list):
+                        groups = [g for g in raw if isinstance(g, dict)]
+
+                for group in groups:
+                    if group.get("_id") != gid:
+                        continue
+                    group_eid = group.get("eid")
+                    group_aid = group.get("aid")
+                    sym_keys = group.get("symmetricKeys")
+                    if not isinstance(group_eid, str) or not group_eid:
+                        continue
+                    if not isinstance(group_aid, str) or not group_aid:
+                        continue
+                    if not isinstance(sym_keys, list) or not sym_keys:
+                        continue
+                    first_key = sym_keys[0]
+                    if not isinstance(first_key, dict):
+                        continue
+                    key_cipher = first_key.get("key")
+                    if not isinstance(key_cipher, str) or not key_cipher:
+                        continue
+                    symmetric_key = _rsa_decrypt_base64(key_cipher, private_pem)
+                    return _ProvisioningResult(
+                        symmetric_key=symmetric_key,
+                        gid=gid,
+                        eid=group_eid,
+                        aid=group_aid,
+                    )
+
+            # Refresh identity on miss — login response includes groups
+            async with session.post(
+                f"{PROVISIONING_APP_API_BASE}{PROVISIONING_ENDPOINT_LOGIN}",
+                json={
+                    "assertion": {
+                        "name": email,
+                        "info": {"name": "circle"},
+                        "publicKey": public_pem,
+                        "appId": PROVISIONING_APP_ID,
+                        "appSecret": PROVISIONING_APP_SECRET,
+                        "signature": "",
+                    }
+                },
+                headers={"Content-Type": "application/json"},
+            ) as resp:
+                if resp.status != 200:
+                    continue
+                refresh: dict[str, object] = await resp.json()
+                token = refresh.get("access_token")
+                if isinstance(token, str) and token:
+                    current_access_token = token
+                # Also check groups from the login response itself
+                login_groups_raw = refresh.get("groups")
+                if isinstance(login_groups_raw, list):
+                    for group in login_groups_raw:
+                        if not isinstance(group, dict):
+                            continue
+                        if group.get("_id") != gid:
+                            continue
+                        group_eid = group.get("eid")
+                        group_aid = group.get("aid")
+                        sym_keys = group.get("symmetricKeys")
+                        if not isinstance(group_eid, str) or not group_eid:
+                            continue
+                        if not isinstance(group_aid, str) or not group_aid:
+                            continue
+                        if not isinstance(sym_keys, list) or not sym_keys:
+                            continue
+                        first_key = sym_keys[0]
+                        if not isinstance(first_key, dict):
+                            continue
+                        key_cipher = first_key.get("key")
+                        if not isinstance(key_cipher, str) or not key_cipher:
+                            continue
+                        symmetric_key = _rsa_decrypt_base64(key_cipher, private_pem)
+                        return _ProvisioningResult(
+                            symmetric_key=symmetric_key,
+                            gid=gid,
+                            eid=group_eid,
+                            aid=group_aid,
+                        )
+
+        raise RuntimeError(
+            "Cloud provisioning did not produce a visible group before "
+            f"timing out after {PROVISIONING_GROUP_POLL_ATTEMPTS} attempts"
+        )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -135,6 +461,46 @@ def build_parser() -> argparse.ArgumentParser:
         type=float,
         default=DEFAULT_CONNECT_TIMEOUT,
         help="SSH connection timeout in seconds",
+    )
+    parser.add_argument(
+        "--qr-json",
+        help=(
+            "Raw QR JSON string from the Firewalla app. "
+            "On Windows, use --qr-file instead to avoid shell quoting issues."
+        ),
+    )
+    parser.add_argument(
+        "--qr-file",
+        type=Path,
+        help=(
+            "Path to a file containing the raw QR JSON. "
+            "Recommended over --qr-json on Windows to avoid quoting issues."
+        ),
+    )
+    parser.add_argument(
+        "--email",
+        help=(
+            "Email or label for the cloud provisioning identity (required when "
+            "--qr-json or --qr-file is provided)"
+        ),
+    )
+    parser.add_argument(
+        "--decode",
+        type=Path,
+        help="Path to a pcap file to decode using a provisioning key file",
+    )
+    parser.add_argument(
+        "--key-file",
+        type=Path,
+        help="Path to a .key file (produced by --qr-json during capture)",
+    )
+    parser.add_argument(
+        "--redacted-report",
+        type=Path,
+        help=(
+            "Path to write a JSON report with credential values redacted. "
+            "Use with --decode to share message structures without exposing keys."
+        ),
     )
     return parser
 
@@ -311,6 +677,7 @@ def parse_http_messages(
                 first_line=first_line,
                 headers=headers,
                 content_length=len(body),
+                body=body,
             )
         )
         index = body_end
@@ -756,10 +1123,148 @@ def download_capture(client: SSHClient, local_path: Path) -> None:
         scp.get(REMOTE_PCAP_PATH, str(local_path))
 
 
+_REDACT_LABEL: Final = "<redacted>"
+
+
+def _redact_credentials(value: object) -> object:
+    """Replace credential values with a redacted label, keeping structure intact."""
+    if isinstance(value, dict):
+        redacted: dict[str, object] = {}
+        for k, v in value.items():
+            if k.lower() in (
+                "eid",
+                "aid",
+                "gid",
+                "symmetric_key",
+                "accesstoken",
+                "access_token",
+                "token",
+                "password",
+                "secret",
+            ) or (isinstance(v, str) and len(v) == 36 and v.count("-") == 4):
+                redacted[k] = _REDACT_LABEL
+            else:
+                redacted[k] = _redact_credentials(v)
+        return redacted
+    if isinstance(value, list):
+        return [_redact_credentials(item) for item in value]
+    return value
+
+
+def _decode_capture(
+    pcap_path: Path, key_path: Path, redacted_report: Path | None = None
+) -> int:
+    """Decode a captured pcap using the sidecar key file and print message contents."""
+    if not pcap_path.is_file():
+        print(f"Error: pcap file not found: {pcap_path}", file=sys.stderr)
+        return 1
+    if not key_path.is_file():
+        print(f"Error: key file not found: {key_path}", file=sys.stderr)
+        return 1
+    if IP is None or TCP is None or rdpcap is None:
+        print("Error: scapy is required for decoding", file=sys.stderr)
+        return 1
+
+    key_data = json.loads(key_path.read_text(encoding="utf-8"))
+    symmetric_key = key_data.get("symmetric_key")
+    if not isinstance(symmetric_key, str) or not symmetric_key:
+        print("Error: key file does not contain a valid symmetric_key", file=sys.stderr)
+        return 1
+
+    decoded_messages: list[dict[str, object]] = []
+    flows_data: dict[tuple, list[Segment]] = defaultdict(list)
+    for packet in rdpcap(str(pcap_path)):
+        if IP not in packet or TCP not in packet:
+            continue
+        ip = packet[IP]
+        tcp = packet[TCP]
+        if tcp.sport != SERVER_PORT and tcp.dport != SERVER_PORT:
+            continue
+        payload = bytes(tcp.payload)
+        if not payload:
+            continue
+        flows_data[(ip.src, tcp.sport, ip.dst, tcp.dport)].append(
+            Segment(seq=int(tcp.seq), data=payload, ts=float(packet.time))
+        )
+
+    for flow, segments in sorted(flows_data.items()):
+        is_request = flow[3] == SERVER_PORT
+        direction = "REQUEST" if is_request else "RESPONSE"
+        blob, offsets = reassemble(segments)
+        messages = parse_http_messages(blob, offsets, request=is_request)
+        for msg in messages:
+            entry: dict[str, object] = {
+                "direction": direction,
+                "first_line": msg.first_line,
+                "content_length": msg.content_length,
+            }
+            if msg.body:
+                try:
+                    body = json.loads(msg.body.decode("utf-8", errors="ignore"))
+                except json.JSONDecodeError:
+                    entry["raw_body"] = msg.body[:200].decode(
+                        "latin1", errors="replace"
+                    )
+                    decoded_messages.append(entry)
+                    continue
+                encrypted = body.get("message") if isinstance(body, dict) else None
+                if isinstance(encrypted, str):
+                    try:
+                        decrypted = _aes256_cbc_decrypt_from_base64(
+                            encrypted, symmetric_key
+                        )
+                        parsed = json.loads(decrypted)
+                        entry["decrypted"] = parsed
+                    except Exception as exc:
+                        entry["decrypt_error"] = str(exc)
+                else:
+                    entry["body"] = body
+            decoded_messages.append(entry)
+
+    # Print full output
+    for entry in decoded_messages:
+        print(f"\n{'=' * 60}")
+        print(f"[{entry['direction']}] {entry['first_line']}")
+        print(f"  content_length: {entry.get('content_length', '')}")
+        if "decrypted" in entry:
+            print(f"  decrypted: {json.dumps(entry['decrypted'], indent=2)}")
+        elif "body" in entry:
+            print(f"  body: {json.dumps(entry['body'], indent=2)}")
+        elif "raw_body" in entry:
+            print(f"  body (raw): {entry['raw_body']}")
+
+    # Write redacted report if requested
+    if redacted_report:
+        redacted_entries = _redact_credentials(decoded_messages)
+        assert isinstance(redacted_entries, list)
+        redacted_report.write_text(
+            json.dumps(redacted_entries, indent=2),
+            encoding="utf-8",
+        )
+        print(f"\nRedacted report saved to: {redacted_report}")
+        print(
+            "This report can be shared — credential values have been replaced "
+            "with <redacted>."
+        )
+    return 0
+
+
 def main() -> int:
     """Run the Windows Firewalla packet capture workflow."""
     parser = build_parser()
     args = parser.parse_args()
+
+    # Decode mode: skip capture and just decode an existing pcap
+    if args.decode:
+        if not args.key_file:
+            print(
+                "Error: --key-file is required when --decode is provided",
+                file=sys.stderr,
+            )
+            return 1
+        return _decode_capture(
+            args.decode, args.key_file, redacted_report=args.redacted_report
+        )
 
     try:
         require_dependencies()
@@ -769,6 +1274,60 @@ def main() -> int:
 
     assert paramiko is not None
     assert SCPException is not None
+
+    # Optional: run cloud provisioning to capture the symmetric key
+    key_path: Path | None = None
+    qr_raw: str | None = args.qr_json
+    if qr_raw is None and args.qr_file is not None:
+        try:
+            qr_raw = args.qr_file.read_text(encoding="utf-8").strip()
+        except OSError as err:
+            print(f"Error: could not read QR file: {err}", file=sys.stderr)
+            return 1
+    if qr_raw is not None:
+        if not args.email:
+            print(
+                "Error: --email is required when --qr-json or --qr-file is provided",
+                file=sys.stderr,
+            )
+            return 1
+        if aiohttp is None or not CRYPTOGRAPHY_AVAILABLE:
+            print(
+                "Error: aiohttp and cryptography are required for provisioning. "
+                "Install them with: pip install aiohttp cryptography",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            qr_data = _ProvisioningQrData.from_raw_json(qr_raw)
+            private_pem, public_pem = _generate_firewalla_keys()
+            print("Starting cloud provisioning to capture the symmetric key...")
+            result = asyncio.run(
+                _provision_symmetric_key(qr_data, private_pem, public_pem, args.email)
+            )
+            ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+            key_path = Path(args.output_dir) / f"provisioning_key_{ts}.key"
+            key_path.write_text(
+                json.dumps(
+                    {
+                        "symmetric_key": result.symmetric_key,
+                        "gid": result.gid,
+                        "eid": result.eid,
+                        "aid": result.aid,
+                        "provisioned_at_utc": datetime.utcnow().isoformat() + "Z",
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            print(f"Symmetric key captured and saved to: {key_path}")
+            print(
+                "This key can decrypt the pcap from this session. "
+                "Keep it private — do not share publicly or include in safe reports."
+            )
+        except (ValueError, RuntimeError, OSError, aiohttp.ClientError) as err:
+            print(f"Cloud provisioning failed: {err}", file=sys.stderr)
+            return 1
 
     host = prompt_host(args.host)
     password = getpass.getpass(f"SSH password for {SSH_USER}@{host}: ")
@@ -818,6 +1377,12 @@ def main() -> int:
 
         print()
         print(f"Success. Capture saved to: {local_capture_path}")
+        if key_path is not None:
+            print(f"Provisioning key saved to: {key_path}")
+            print(
+                "Keep the key file private — it can decrypt this pcap. "
+                "Only share alongside the raw pcap privately."
+            )
         if report_path is not None:
             print(f"Safe report saved to: {report_path}")
             print("Share the safe report first and keep the raw pcap private.")

--- a/tools/support/capture_firewalla_packets_requirements.txt
+++ b/tools/support/capture_firewalla_packets_requirements.txt
@@ -1,3 +1,5 @@
 paramiko>=3.5.0
 scp>=0.15.0
 scapy>=2.6.1
+aiohttp>=3.9.0
+cryptography>=42.0.0


### PR DESCRIPTION
This pull request significantly improves the documentation and usability for reverse engineering and capturing Firewalla pairing and local protocol traffic. The main changes include a comprehensive, step-by-step explanation of the full pairing protocol, a rewritten Windows packet capture guide for clarity and ease of use, and updated requirements for the capture tooling.

**Documentation improvements:**

* Added a detailed, end-to-end explanation of the Firewalla pairing protocol to `docs/REVERSE_ENGINEERING_WORKFLOW.md`, including QR code structure, cryptographic steps, cloud provisioning, and key handling. This makes the previously undocumented protocol accessible and clear for future development and troubleshooting.
* Updated `docs/ARCHITECTURE.md` to reference the new full-sequence pairing protocol documentation and improved formatting for protocol facts.

**Packet capture workflow and tooling:**

* Completely rewrote `WINDOWS_PACKET_CAPTURE_USAGE.md` to provide a streamlined, step-by-step workflow for capturing phone pairing sessions, saving the symmetric key, and generating safe, shareable analysis reports. The guide now emphasizes clarity, security, and practical troubleshooting steps.
* Updated `capture_firewalla_packets_requirements.txt` to include `aiohttp` and `cryptography` dependencies, supporting the enhanced capture and decryption workflow.## Summary

Related to Issue #14 