### PR TITLE
Enhance payload structure for pairing compatibility and debug output

### DIFF
--- a/custom_components/firewalla_local/api/client.py
+++ b/custom_components/firewalla_local/api/client.py
@@ -54,6 +54,7 @@ _RAW_MESSAGE_ERROR_KEY: Final = "error"
 _RAW_MESSAGE_DATA_KEY: Final = "data"
 _RAW_MESSAGE_CODE_KEY: Final = "code"
 _RAW_MESSAGE_TIMESTAMP_KEY: Final = "timestamp"
+_RAW_MESSAGE_MTYPE_KEY: Final = "mtype"
 
 _COMMAND_MESSAGE_TYPE: Final = "cmd"
 _GET_MESSAGE_TYPE: Final = "get"
@@ -365,6 +366,7 @@ class FirewallaApiClient:
         payload = {
             _RAW_MESSAGE_KEY: encrypted_message,
             _RAW_MESSAGE_TIMESTAMP_KEY: int(time.time()),
+            _RAW_MESSAGE_MTYPE_KEY: "msg",
         }
 
         response_status, response_text = await self._async_post_local_payload(

--- a/custom_components/firewalla_local/manifest.json
+++ b/custom_components/firewalla_local/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/ccpk1/firewalla-local-ha/issues",
   "loggers": ["custom_components.firewalla_local"],
   "requirements": ["cryptography>=44.0.0"],
-  "version": "1.1.6"
+  "version": "1.1.7-beta.1"
 }

--- a/docs/REVERSE_ENGINEERING_WORKFLOW.md
+++ b/docs/REVERSE_ENGINEERING_WORKFLOW.md
@@ -286,7 +286,7 @@ RSA decrypt (2048-bit private key) ──> raw symmetric key material
 Every local POST:
   build Firewalla envelope (mtype + message with from/obj/appInfo)
   json.dumps(envelope, separators=(",", ":")) ──> AES-256-CBC(key) ──> base64
-  payload = {"message": base64_ciphertext, "timestamp": <now>}
+  payload = {"message": base64_ciphertext, "timestamp": <now>, "mtype": "msg"}
   POST http://{host}:8833/v1/encipher/message/{gid}
 ```
 
@@ -1896,3 +1896,139 @@ When a new capture is completed:
 - record the implementation impact if the new family changes switch behavior
 
 Do not summarize away payload fields that may later matter for the protocol.
+
+## Appendix: APK reverse engineering
+
+This section documents how the Firewalla Android APK was obtained and
+decompiled during the Gold SE 412 investigation (Issue 14). It is preserved
+here so the process can be reproduced when a newer app version needs analysis.
+
+### Downloading the APK
+
+1. **Find the APK on a third-party APK mirror.** The Firewalla app (package
+   `com.firewalla.chancellor`) is available from sites such as APKMirror or
+   APKPure. Search for `Firewalla` and download the variant matching the
+   target version.
+
+2. **Extract the APK.** If the download is an `.apkm` (APK Mirror bundle),
+   extract it — the main APK file is the one with the package name, e.g.
+   `com.firewalla.chancellor.apk`.
+
+3. **Verify the manifest.** The APK metadata (package, version, SDK levels)
+   can be read without decompilation:
+   ```bash
+   unzip -p com.firewalla.chancellor.apk AndroidManifest.xml | strings | head -30
+   ```
+   The confirmed identifiers are `com.firewalla.chancellor`, version
+   `1.69.1 (27)`, min SDK 29, target SDK 36.
+
+### Decompiling with JADX
+
+[JADX](https://github.com/skylot/jadx) is a DEX-to-Java decompiler that
+handles most ProGuard / R8 obfuscation.
+
+1. **Install JADX** (if not already present):
+
+   ```bash
+   # Download the latest release
+   curl -L -o jadx.zip https://github.com/skylot/jadx/releases/download/v1.5.1/jadx-1.5.1.zip
+   unzip jadx.zip -d /tmp/jadx
+   ```
+
+2. **Run JADX:**
+
+   ```bash
+   /tmp/jadx/bin/jadx -d /tmp/jadx_src --show-bad-code -j 8 \
+     /path/to/com.firewalla.chancellor.apk
+   ```
+
+   - `-d` — output directory for decompiled Java sources
+   - `--show-bad-code` — emit decompilation attempts even for methods JADX
+     cannot fully recover (due to R8 control-flow flattening)
+   - `-j 8` — use 8 parallel threads
+
+3. **Expected outcome.** The majority of the codebase decompiles into readable
+   Java under `/tmp/jadx_src/sources/defpackage/`. Some methods in classes
+   like `fy3`, `s73`, and `a93` will fail to decompile due to R8 control-flow
+   flattening — their bodies emit as error stubs or bad-code blocks. These
+   methods can still be inspected at the Smali level if needed (see below).
+
+### Key files in the decompiled source
+
+| File | Purpose |
+| --- | --- |
+| `wx3.java` | Message envelope builder. `d()` constructs the inner encrypted JSON; `c()` builds the outer HTTP payload with `timestamp` and `message` keys. |
+| `y2.java` | Message sending coroutine. Case 2 handles local encipher messages — it calls `wx3.c()` then adds `"mtype":"msg"` to the outer payload. |
+| `s73.java` | HTTP client for local communication. The `U()` method (heavily obfuscated) orchestrates message sending. |
+| `n73.java` | Network model / box descriptor. Contains model sets including `gse` (Gold SE) alongside `gold`, `gold_plus`, etc. |
+| `fy3.java` | Main message hub / router — sends messages via cloud (`a()`) and local (`b()`) paths. Contains obfuscated methods. |
+
+### Confirmed outer payload format (Android app v1.69.1)
+
+From `y2.java` case 2 and `wx3.java`:
+
+```java
+// wx3.c() builds:
+JSONObject outer = new JSONObject();
+outer.put("timestamp", System.currentTimeMillis() / 1000);
+outer.put("message", encrypted_payload);
+
+// y2.java caller then adds:
+outer.put("mtype", "msg");       // ← confirms mtype in outer envelope
+outer.put("rkeyts", 1);          // ← added when no ts in box metadata
+```
+
+The final HTTP body sent to `POST /v1/encipher/message/{gid}`:
+
+```json
+{"timestamp": 1234567890, "message": "<encrypted>", "mtype": "msg"}
+```
+
+This confirmed that the phone app sends **both** `timestamp` and `mtype: msg`
+in the outer payload — the integration was missing only `mtype`.
+
+### Inner encrypted envelope format (for reference)
+
+From `wx3.d()`:
+
+```java
+String inner = "{\"message\":{\"mtype\":\"msg\",\"type\":\"jsondata\",\"msg\":\"\",\"from\":\"Android\""
+    + ",\"obj\":" + serialized_obj
+    + ",\"appInfo\":" + app_info_json
+    + ",\"compressMode\":1}, \"mtype\":\"msg\"}";
+```
+
+This produces a nested JSON that gets encrypted and placed in the outer
+`"message"` field. The integration uses the equivalent structure directly
+(without the redundant outer `"message"` wrapper) by building the inner
+envelope as a flat object.
+
+### Alternative: Smali extraction via Apktool
+
+For methods that JADX cannot decompile (R8 control-flow flattening), the
+Smali assembly is always recoverable:
+
+```bash
+# Install Apktool
+curl -L -o /tmp/apktool.jar https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_2.10.0.jar
+
+# Decompile to Smali
+java -jar /tmp/apktool.jar d com.firewalla.chancellor.apk -o /tmp/apktool_out
+
+# Search for specific method
+grep -rn ".method.*sendMessage\|.method.*encrypt\|.method.*buildPayload" /tmp/apktool_out/
+```
+
+Smali preserves all instructions including those lost to control-flow
+flattening, at the cost of readability.
+
+### Reproducibility notes
+
+- JADX output is deterministic for a given APK and version — re-running
+  produces the same decompiled source.
+- The obfuscated class names (e.g., `wx3`, `y2`, `s73`, `fy3`) are assigned
+  by ProGuard/R8 and will differ between app versions. Search by string
+  constants (`"mtype"`, `"compressMode"`, `"com.rottiesoft.circle"`) to
+  locate the equivalent classes in a newer APK.
+- The APK used for this analysis was `com.firewalla.chancellor` version
+  `1.69.1 (27)`. Later versions may change the message format.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-firewalla-local"
-version = "1.1.6"
+version = "1.1.7-beta.1"
 description = "Local-first Home Assistant custom integration for Firewalla"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/tools/support/capture_firewalla_packets.py
+++ b/tools/support/capture_firewalla_packets.py
@@ -1217,6 +1217,12 @@ def _decode_capture(
                         entry["decrypted"] = parsed
                     except Exception as exc:
                         entry["decrypt_error"] = str(exc)
+                    # Preserve outer envelope keys (everything except the
+                    # encrypted message blob) so users can inspect fields like
+                    # mtype, timestamp, rkeyts, etc.
+                    outer = {k: v for k, v in body.items() if k != "message"}
+                    if outer:
+                        entry["outer_envelope"] = outer
                 else:
                     entry["body"] = body
             decoded_messages.append(entry)
@@ -1226,6 +1232,8 @@ def _decode_capture(
         print(f"\n{'=' * 60}")
         print(f"[{entry['direction']}] {entry['first_line']}")
         print(f"  content_length: {entry.get('content_length', '')}")
+        if outer := entry.get("outer_envelope"):
+            print(f"  outer_envelope: {json.dumps(outer)}")
         if "decrypted" in entry:
             print(f"  decrypted: {json.dumps(entry['decrypted'], indent=2)}")
         elif "body" in entry:


### PR DESCRIPTION
This pull request adds support for the `"mtype"` field in outgoing local message payloads to match the Firewalla Android app's protocol, updates documentation to reflect this, and improves tooling for protocol analysis and reverse engineering. It also bumps the integration version to `1.1.7-beta.1`.

**Protocol compliance and feature updates:**

* [`client.py`](diffhunk://#diff-6f0f34e6f7600b33fac3b655d201469cba2422831c28567427d89eb66718c862R57): Adds the `"mtype": "msg"` field to the outer payload of local POST requests, ensuring compatibility with the Firewalla app protocol. [[1]](diffhunk://#diff-6f0f34e6f7600b33fac3b655d201469cba2422831c28567427d89eb66718c862R57) [[2]](diffhunk://#diff-6f0f34e6f7600b33fac3b655d201469cba2422831c28567427d89eb66718c862R369)
* `manifest.json`, `pyproject.toml`: Updates the integration version to `1.1.7-beta.1`. [[1]](diffhunk://#diff-5839a5201f0acd106bd803dffd506cf394aa2aef82256af5c24b33ff7f2b6373L12-R12) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7)

**Documentation improvements:**

* [`REVERSE_ENGINEERING_WORKFLOW.md`](diffhunk://#diff-fd6e07db15ff99fc48b883ece82e3df58f0e985adb1c2766b60f2a34a8e90e37L289-R289): Updates protocol documentation to include the `"mtype"` field in the POST payload and adds a detailed appendix on APK reverse engineering and payload format confirmation. [[1]](diffhunk://#diff-fd6e07db15ff99fc48b883ece82e3df58f0e985adb1c2766b60f2a34a8e90e37L289-R289) [[2]](diffhunk://#diff-fd6e07db15ff99fc48b883ece82e3df58f0e985adb1c2766b60f2a34a8e90e37R1899-R2034)

**Tooling enhancements:**

* [`capture_firewalla_packets.py`](diffhunk://#diff-511a5b5867901c3701781777132aa801af6acef135860516bc040aeb863b4a1cR1220-R1225): Enhances the capture decoding tool to preserve and display all outer envelope fields (such as `mtype`, `timestamp`, `rkeyts`) for easier protocol analysis. [[1]](diffhunk://#diff-511a5b5867901c3701781777132aa801af6acef135860516bc040aeb863b4a1cR1220-R1225) [[2]](diffhunk://#diff-511a5b5867901c3701781777132aa801af6acef135860516bc040aeb863b4a1cR1235-R1236)