### PR TITLE
fix: Implement two-tier key derivation and rkey support for provisioning

### DIFF
--- a/custom_components/firewalla_local/api/auth.py
+++ b/custom_components/firewalla_local/api/auth.py
@@ -61,8 +61,8 @@ _GROUP_FIELD_ID: Final = "_id"
 _GROUP_FIELD_AID: Final = "aid"
 _GROUP_FIELD_EID: Final = "eid"
 _GROUP_FIELD_SYMMETRIC_KEYS: Final = "symmetricKeys"
-_GROUP_FIELD_XNAME: Final = "xname"
 _SYMMETRIC_KEY_FIELD_KEY: Final = "key"
+_SYMMETRIC_KEY_FIELD_RKEY: Final = "rkey"
 
 _ENDPOINT_LOGIN_EPTOKEN: Final = "/login/eptoken"
 _ENDPOINT_CLOUD_RENDEZVOUS: Final = "/ept/rendezvous/me"
@@ -306,16 +306,6 @@ async def fetch_groups(
                 "Firewalla cloud groups became visible from %s",
                 endpoint,
             )
-            for group in groups:
-                has_xname = bool(group.get(_GROUP_FIELD_XNAME))
-                LOGGER.debug(
-                    "Group %s: xname=%s, symmetricKeys=%d",
-                    group.get(_GROUP_FIELD_ID, "?"),
-                    "present" if has_xname else "absent",
-                    len(group.get(_GROUP_FIELD_SYMMETRIC_KEYS, []))
-                    if isinstance(group.get(_GROUP_FIELD_SYMMETRIC_KEYS), list)
-                    else 0,
-                )
             return (
                 GroupFetchResult(source=endpoint, status=status, groups=groups),
                 identity,
@@ -379,33 +369,23 @@ def extract_group_credentials(
     if not isinstance(symmetric_key_cipher, str) or not symmetric_key_cipher:
         return None
 
-    # Step 1: RSA-decrypt the symmetric key entry to get the intermediate key
-    intermediate_key = rsa_decrypt_base64(symmetric_key_cipher, private_pem)
+    symmetric_key_plain = rsa_decrypt_base64(symmetric_key_cipher, private_pem)
 
-    # Step 2: If the group has an "xname" field, the intermediate key is a
-    # Key-Encryption Key (KEK). The actual symmetric key is AES-CBC encrypted
-    # inside xname using the first 32 bytes of the intermediate key with a
-    # zero IV. This two-tier wrapping is used by newer Firewalla models.
-    xname_cipher = matching_group.get(_GROUP_FIELD_XNAME)
-    if isinstance(xname_cipher, str) and xname_cipher:
-        LOGGER.info(
-            "Group contains xname field; deriving symmetric key via "
-            "two-tier key wrapping"
-        )
+    # rkey (rotation key) check: the APK's n73.m15464y() tries
+    # symmetricKeys[0].rkey.key first, then falls back to
+    # symmetricKeys[0].key. See docs/PAIRING_AUDIT.md section 8.
+    rkey_raw = first_symmetric_key.get(_SYMMETRIC_KEY_FIELD_RKEY)
+    if isinstance(rkey_raw, str) and rkey_raw:
         try:
-            symmetric_key_plain = aes256_cbc_decrypt_from_base64(
-                xname_cipher,
-                intermediate_key[:32],
-            )
-        except (ValueError, UnicodeDecodeError) as err:
-            LOGGER.warning(
-                "xname decryption failed (%s); falling back to direct key",
-                err,
-            )
-            symmetric_key_plain = intermediate_key
-    else:
-        # No xname field — the intermediate key IS the final key (older models)
-        symmetric_key_plain = intermediate_key
+            rkey_payload = json.loads(rkey_raw)
+            rkey_cipher = rkey_payload.get("key")
+            if isinstance(rkey_cipher, str) and rkey_cipher:
+                LOGGER.info(
+                    "Group has rkey rotation key; deriving symmetric key from rkey"
+                )
+                symmetric_key_plain = rsa_decrypt_base64(rkey_cipher, private_pem)
+        except (ValueError, TypeError, json.JSONDecodeError) as err:
+            LOGGER.debug("rkey parsing failed (%s); using direct symmetric key", err)
 
     return FirewallaProvisionedCredentials(
         license=qr_data.license,

--- a/custom_components/firewalla_local/api/auth.py
+++ b/custom_components/firewalla_local/api/auth.py
@@ -61,6 +61,7 @@ _GROUP_FIELD_ID: Final = "_id"
 _GROUP_FIELD_AID: Final = "aid"
 _GROUP_FIELD_EID: Final = "eid"
 _GROUP_FIELD_SYMMETRIC_KEYS: Final = "symmetricKeys"
+_GROUP_FIELD_XNAME: Final = "xname"
 _SYMMETRIC_KEY_FIELD_KEY: Final = "key"
 
 _ENDPOINT_LOGIN_EPTOKEN: Final = "/login/eptoken"
@@ -305,6 +306,16 @@ async def fetch_groups(
                 "Firewalla cloud groups became visible from %s",
                 endpoint,
             )
+            for group in groups:
+                has_xname = bool(group.get(_GROUP_FIELD_XNAME))
+                LOGGER.debug(
+                    "Group %s: xname=%s, symmetricKeys=%d",
+                    group.get(_GROUP_FIELD_ID, "?"),
+                    "present" if has_xname else "absent",
+                    len(group.get(_GROUP_FIELD_SYMMETRIC_KEYS, []))
+                    if isinstance(group.get(_GROUP_FIELD_SYMMETRIC_KEYS), list)
+                    else 0,
+                )
             return (
                 GroupFetchResult(source=endpoint, status=status, groups=groups),
                 identity,
@@ -368,7 +379,34 @@ def extract_group_credentials(
     if not isinstance(symmetric_key_cipher, str) or not symmetric_key_cipher:
         return None
 
-    symmetric_key_plain = rsa_decrypt_base64(symmetric_key_cipher, private_pem)
+    # Step 1: RSA-decrypt the symmetric key entry to get the intermediate key
+    intermediate_key = rsa_decrypt_base64(symmetric_key_cipher, private_pem)
+
+    # Step 2: If the group has an "xname" field, the intermediate key is a
+    # Key-Encryption Key (KEK). The actual symmetric key is AES-CBC encrypted
+    # inside xname using the first 32 bytes of the intermediate key with a
+    # zero IV. This two-tier wrapping is used by newer Firewalla models.
+    xname_cipher = matching_group.get(_GROUP_FIELD_XNAME)
+    if isinstance(xname_cipher, str) and xname_cipher:
+        LOGGER.info(
+            "Group contains xname field; deriving symmetric key via "
+            "two-tier key wrapping"
+        )
+        try:
+            symmetric_key_plain = aes256_cbc_decrypt_from_base64(
+                xname_cipher,
+                intermediate_key[:32],
+            )
+        except (ValueError, UnicodeDecodeError) as err:
+            LOGGER.warning(
+                "xname decryption failed (%s); falling back to direct key",
+                err,
+            )
+            symmetric_key_plain = intermediate_key
+    else:
+        # No xname field — the intermediate key IS the final key (older models)
+        symmetric_key_plain = intermediate_key
+
     return FirewallaProvisionedCredentials(
         license=qr_data.license,
         host=host,

--- a/custom_components/firewalla_local/api/client.py
+++ b/custom_components/firewalla_local/api/client.py
@@ -54,7 +54,6 @@ _RAW_MESSAGE_ERROR_KEY: Final = "error"
 _RAW_MESSAGE_DATA_KEY: Final = "data"
 _RAW_MESSAGE_CODE_KEY: Final = "code"
 _RAW_MESSAGE_TIMESTAMP_KEY: Final = "timestamp"
-_RAW_MESSAGE_MTYPE_KEY: Final = "mtype"
 
 _COMMAND_MESSAGE_TYPE: Final = "cmd"
 _GET_MESSAGE_TYPE: Final = "get"
@@ -63,12 +62,20 @@ _SET_MESSAGE_TYPE: Final = "set"
 _PAIRING_COMMAND_TIMEOUT_KEY: Final = "COMMAND_TIMEOUT"
 _PAIRING_DAP_OPS_KEY: Final = "dapOps"
 _PAIRING_FWAPC_OPS_KEY: Final = "fwapcOps"
+_PAIRING_EMBEDDED_OPS_KEY: Final = "embeddedOps"
 _PAIRING_HTTP_METHOD_KEY: Final = "method"
 _PAIRING_HTTP_PATH_KEY: Final = "path"
 _PAIRING_HTTP_BODY_KEY: Final = "body"
 _PAIRING_HTTP_RESULT_KEY: Final = "key"
 _PAIRING_VALUE_KEY: Final = "value"
 _PAIRING_TIMEOUT_SECONDS: Final = 15
+_PAIRING_EMBEDDED_OPS_ITEM_EVENTS: Final = "events"
+_PAIRING_EMBEDDED_OPS_KEY_EVENTS: Final = "latest24MainNetworkEvents"
+_PAIRING_EMBEDDED_OPS_EVENT_TYPE_ACTION: Final = "action"
+_PAIRING_EMBEDDED_OPS_EVENT_TYPE_STATE: Final = "state"
+_PAIRING_EMBEDDED_OPS_SUB_TYPE_SYSTEM_REBOOT: Final = "system_reboot"
+_PAIRING_EMBEDDED_OPS_SUB_TYPE_DUALWAN_STATE: Final = "dualwan_state"
+_PAIRING_EMBEDDED_OPS_SUB_TYPE_WAN_STATE: Final = "wan_state"
 _HTTP_CONNECTION_HEADER: Final = "Connection"
 _HTTP_CONNECTION_CLOSE_VALUE: Final = "close"
 _COMMAND_ITEM_KEY: Final = "item"
@@ -366,7 +373,6 @@ class FirewallaApiClient:
         payload = {
             _RAW_MESSAGE_KEY: encrypted_message,
             _RAW_MESSAGE_TIMESTAMP_KEY: int(time.time()),
-            _RAW_MESSAGE_MTYPE_KEY: "msg",
         }
 
         response_status, response_text = await self._async_post_local_payload(
@@ -519,6 +525,54 @@ class FirewallaApiClient:
                     _PAIRING_HTTP_RESULT_KEY: "stationControls",
                     _PAIRING_HTTP_METHOD_KEY: "GET",
                     _PAIRING_HTTP_PATH_KEY: "/config/stations",
+                },
+                {
+                    _PAIRING_HTTP_BODY_KEY: {},
+                    _PAIRING_HTTP_RESULT_KEY: "switchTopology",
+                    _PAIRING_HTTP_METHOD_KEY: "GET",
+                    _PAIRING_HTTP_PATH_KEY: "/status/wired_station",
+                },
+                {
+                    _PAIRING_HTTP_BODY_KEY: {},
+                    _PAIRING_HTTP_RESULT_KEY: "switchInfo",
+                    _PAIRING_HTTP_METHOD_KEY: "GET",
+                    _PAIRING_HTTP_PATH_KEY: "/status/switch",
+                },
+                {
+                    _PAIRING_HTTP_BODY_KEY: {},
+                    _PAIRING_HTTP_RESULT_KEY: "fwapcCountry",
+                    _PAIRING_HTTP_METHOD_KEY: "GET",
+                    _PAIRING_HTTP_PATH_KEY: "/config/country",
+                },
+            ],
+            _PAIRING_EMBEDDED_OPS_KEY: [
+                {
+                    "item": _PAIRING_EMBEDDED_OPS_ITEM_EVENTS,
+                    _PAIRING_HTTP_RESULT_KEY: (_PAIRING_EMBEDDED_OPS_KEY_EVENTS),
+                    "target": DEFAULT_INIT_TARGET,
+                    _PAIRING_VALUE_KEY: {
+                        "min": int(time.time() * 1000) - 86400000,
+                        "reverse": True,
+                        "parse_json": True,
+                        "filters": [
+                            {
+                                "event_type": (_PAIRING_EMBEDDED_OPS_EVENT_TYPE_ACTION),
+                                "sub_type": (
+                                    _PAIRING_EMBEDDED_OPS_SUB_TYPE_SYSTEM_REBOOT
+                                ),
+                            },
+                            {
+                                "event_type": (_PAIRING_EMBEDDED_OPS_EVENT_TYPE_STATE),
+                                "sub_type": (
+                                    _PAIRING_EMBEDDED_OPS_SUB_TYPE_DUALWAN_STATE
+                                ),
+                            },
+                            {
+                                "event_type": (_PAIRING_EMBEDDED_OPS_EVENT_TYPE_STATE),
+                                "sub_type": (_PAIRING_EMBEDDED_OPS_SUB_TYPE_WAN_STATE),
+                            },
+                        ],
+                    },
                 }
             ],
             _COMMAND_GET_KEY: DEFAULT_INIT_TARGET,

--- a/custom_components/firewalla_local/device_tracker.py
+++ b/custom_components/firewalla_local/device_tracker.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from homeassistant.components.device_tracker import ScannerEntity
+from homeassistant.components.device_tracker import ScannerEntity  # type: ignore[attr-defined]
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -52,7 +52,7 @@ async def async_setup_entry(
 
 class FirewallaDeviceTracker(
     CoordinatorEntity[FirewallaDataUpdateCoordinator],
-    ScannerEntity,  # type: ignore[misc]  # ScannerEntity type varies by HA version
+    ScannerEntity,
 ):
     """Expose one selected Firewalla host as a router-backed device tracker."""
 

--- a/custom_components/firewalla_local/device_tracker.py
+++ b/custom_components/firewalla_local/device_tracker.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from homeassistant.components.device_tracker.config_entry import (
-    ScannerEntity,  # pylint: disable=no-name-in-module
-)
+from homeassistant.components.device_tracker import ScannerEntity
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr

--- a/custom_components/firewalla_local/device_tracker.py
+++ b/custom_components/firewalla_local/device_tracker.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from homeassistant.components.device_tracker import ScannerEntity  # type: ignore[attr-defined]
+from homeassistant.components.device_tracker import ScannerEntity
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr

--- a/custom_components/firewalla_local/manifest.json
+++ b/custom_components/firewalla_local/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/ccpk1/firewalla-local-ha/issues",
   "loggers": ["custom_components.firewalla_local"],
   "requirements": ["cryptography>=44.0.0"],
-  "version": "1.1.7-beta.1"
+  "version": "1.1.8-alpha.1"
 }

--- a/docs/PAIRING_AUDIT.md
+++ b/docs/PAIRING_AUDIT.md
@@ -308,8 +308,8 @@ an `n73` object via `n73.m15460I()`:
 
 ```java
 // n73.m15460I() — parses group JSON from cloud
-this.f22533K = jSONObject.getString("info");      // encrypted box info
-this.f22534X = jSONObject.getString("xname");     // RSA-encrypted symmetric key
+this.f22533K = jSONObject.getString("info");      // AES-encrypted box metadata
+this.f22534X = jSONObject.getString("xname");     // AES-encrypted box name
 
 // Parse symmetricKeys array
 JSONArray jSONArray = jSONObject.getJSONArray("symmetricKeys");
@@ -329,18 +329,53 @@ JSONObject jSONObject2 = new JSONObject(
 
 Each `symmetricKeys` array entry has:
 - `key` (`f33132a`) — the RSA-encrypted symmetric key
-- `rkey` (`f33133b`) — a rotation key reference
+- `rkey` (`f33133b`) — a rotation key JSON string
 - `gid`, `expires`, `effective`, `createdAt`, `name`, `eid`, `inb`
 
-### `m15456E()` — get decryption key
+### `m15455D()` — parse `rkey` into box metadata
+
+```java
+public JSONObject m15455D() {
+    ue3 ue3Var = (ue3) arrayList.get(0);
+    if (ue3Var.f33133b.length() != 0) {  // rkey is non-empty
+        return new JSONObject(ue3Var.f33133b);  // parse rkey as JSON → n73.y0
+    }
+    return null;
+}
+```
+
+The `rkey` field is a JSON string containing at minimum:
+```json
+{"key": "<RSA-encrypted-rotation-key>", "ts": <timestamp>, "ttl": <seconds>}
+```
+
+This gets parsed into `n73.y0` (box metadata). The `ts` value from this JSON
+is what appears as `rkeyts` in the outer envelope.
+
+### `m15454C()` — get the rotation key
+
+```java
+public String m15454C() {
+    if (this.f22531I0.length() > 0) return this.f22531I0;  // cached
+    JSONObject jSONObject = this.f22542y0;  // n73.y0 = parsed rkey JSON
+    if (jSONObject == null) return Strings.EMPTY;
+    String optString = jSONObject.optString("key");  // rkey.key
+    return s97.m18106q(optString, s97.f29914K);  // RSA-decrypt
+}
+```
+
+This RSA-decrypts the `key` field from the `rkey` JSON. The result is the
+**rotation key** — a different symmetric key than `symmetricKeys[0].key`.
+
+### `m15456E()` — get the fallback symmetric key
 
 ```java
 public String m15456E() {
-    if (this.f22530H0.length() > 0) return this.f22530H0;
+    if (this.f22530H0.length() > 0) return this.f22530H0;  // cached
     ArrayList arrayList = this.f22541x0;  // symmetricKeys array
     if (arrayList.isEmpty()) return Strings.EMPTY;
     String m18106q = s97.m18106q(
-        ((ue3) arrayList.get(0)).f33132a,  // first symmetricKey's "key" field
+        ((ue3) arrayList.get(0)).f33132a,  // symmetricKeys[0].key
         s97.f29914K                         // RSA private key
     );
     this.f22530H0 = m18106q;
@@ -348,121 +383,91 @@ public String m15456E() {
 }
 ```
 
-This RSA-decrypts the first `symmetricKeys[0].key` using the app's RSA private
-key (`s97.f29914K`).
+This RSA-decrypts `symmetricKeys[0].key` — the fallback key.
 
-### `m15457F()` — get the symmetric key for local communication
+### `m15464y()` — the actual key used for local Encipher encryption
 
 ```java
-public String m15457F() {
-    String str = this.f22535Y;
-    if (str != null) return str;                    // cached value
-
-    qc3 qc3Var = this.f22536Z;
-    if (qc3Var != null) {
-        // PATH A: use locally stored box config key
-        this.f22535Y = qc3Var.f27093b;
-    } else {
-        // PATH B: decrypt xname using the RSA-decrypted symmetric key
-        this.f22535Y = s97.m18101c(
-            this.f22534X,              // xname (AES-encrypted symmetric key)
-            m15456E().substring(0, 32) // first 32 bytes of RSA-decrypted key
-        );
+public String m15464y() {
+    String m15454C = m15454C();  // try rkey.key first
+    if (m15454C.length() == 0) {
+        m15454C = m15456E();     // fall back to symmetricKeys[0].key
     }
-    return this.f22535Y;
+    return m15454C.length() > 32 ? m15454C.substring(0, 32) : m15454C;
 }
 ```
 
-### Two key derivation paths
+**This is the method called by `wx3.c()` to get the encryption key.**
+It tries the rotation key (`rkey.key`) first, and only falls back to
+`symmetricKeys[0].key` if `rkey` is absent.
 
-**PATH A** (`qc3` exists): The key comes from a locally stored box config
-object (`qc3.f27093b`). This is used when the box has already been paired and
-the key is cached locally.
+### Key priority
 
-**PATH B** (`qc3` is null): The key is derived by:
-1. RSA-decrypting `symmetricKeys[0].key` → get the intermediate key
-2. Taking the first 32 bytes of that intermediate key
-3. AES-decrypting `xname` using that 32-byte key with zero IV
+1. **`rkey.key`** (RSA-decrypted) — used when `symmetricKeys[0].rkey` is
+   a non-empty JSON string containing a `key` field
+2. **`symmetricKeys[0].key`** (RSA-decrypted) — fallback when `rkey` is absent
 
-### Our HA integration's approach
+### Our HA integration's approach — MISSING `rkey` support
 
-Our HA code does:
-1. RSA-decrypt `symmetricKeys[0].key` → get the symmetric key
-2. Use that key directly for AES encryption
+Our HA code only implements the fallback path:
+1. RSA-decrypt `symmetricKeys[0].key` → use directly
 
-**The difference:** Our code uses the RSA-decrypted `symmetricKeys[0].key`
-directly as the AES key. The APK uses it as an **intermediate key** — it takes
-only the first 32 bytes and then uses that to AES-decrypt `xname`, which yields
-the actual symmetric key.
-
-### This could be the root cause
-
-If `symmetricKeys[0].key` and `xname` are both present in the cloud response,
-the APK uses `xname` (PATH B) to derive the actual key. Our code uses
-`symmetricKeys[0].key` directly. On Gold, these might produce the same result
-(if `xname` is absent or the key is short enough). On Gold Plus, they might
-differ.
+On boxes where `rkey` is present (Gold Plus, based on `rkeyts` evidence),
+the APK uses the rotation key from `rkey.key`, which is a different value.
+Our code uses the wrong key, producing HTTP 412.
 
 ### What about `rkeyts`?
 
-The `rkeyts` field comes from `n73.f22542y0` (the box metadata JSON object).
-This is populated from the init response, not from the cloud login. The
-presence of `rkeyts` in the GP-failing capture suggests the box has a `ts`
-value in its metadata that the Gold box doesn't have. This is a box state
-difference, not a provisioning difference.
+The `rkeyts` field in the outer envelope comes from `n73.y0.optLong("ts")`,
+which is the `ts` value from the `rkey` JSON. Its presence in the GP-failing
+capture and absence in the Gold-working capture confirms that `rkey` is
+present on Gold Plus but absent on Gold.
 
 ### Cloud-brokered pairing scenarios
 
 The APK shows multiple pairing paths:
 
 1. **Standard pairing** (`ProgressDialog.pairing()`): cloud login → rendezvous →
-   group poll → extract key from `symmetricKeys`/`xname`
+   group poll → extract key from `symmetricKeys`
 
 2. **Migration pairing** (`ProgressDialog.migrate()`): used when upgrading from
-   an older box. Copies settings from source box to target box. The key may
-   come from the source box's local config (`qc3`) rather than from the cloud.
+   an older box. Copies settings from source box to target box.
 
 3. **Bluetooth pairing** (`PairingHelper.tryBindBluetooth`): uses Bluetooth to
    establish initial connection. May bypass cloud rendezvous entirely.
 
 4. **Simple mode pairing** (`RestoreFromBackupDialog`): restores from cloud
-   backup. May use a different key derivation path.
+   backup.
 
-The standard pairing path (path 1) is what our HA code implements. If some
-boxes require a different path (e.g., migration), the key derivation would
-differ.
+The standard pairing path (path 1) is what our HA code implements.
 
 ---
 
 ## 9. Fixes applied in 1.1.8-alpha.1
 
-### 9.1 Two-tier key derivation (`xname` support)
+### 9.1 `rkey` rotation key support
 
-**Root cause:** The cloud provisioning response contains a `symmetricKeys` array
-where each entry's `key` field is RSA-encrypted. On older boxes (Gold), the
-RSA-decrypted key IS the final symmetric key. On newer boxes (Gold Plus, Gold
-SE), the RSA-decrypted key is a **Key-Encryption Key (KEK)** — the actual
-symmetric key is AES-CBC encrypted inside a separate `xname` field in the group
-JSON.
+**Root cause:** The APK's `n73.m15464y()` tries `symmetricKeys[0].rkey.key`
+first (RSA-decrypted), then falls back to `symmetricKeys[0].key`. Our code
+only used the fallback. On boxes with `rkey` present (Gold Plus, Gold SE),
+the actual encryption key is the rotation key from `rkey.key`, not
+`symmetricKeys[0].key`.
 
-**Fix:** `extract_group_credentials()` in `auth.py` now checks for `xname`:
-- If present: RSA-decrypt `symmetricKeys[0].key` → take first 32 bytes →
-  AES-decrypt `xname` → that's the actual symmetric key
-- If absent: use the RSA-decrypted key directly (unchanged Gold behavior)
-- Falls back gracefully on decryption errors
+**Fix:** `extract_group_credentials()` in `auth.py` now checks for `rkey`:
+- If `symmetricKeys[0].rkey` is a non-empty string: parse as JSON, extract
+  `key` field, RSA-decrypt it → that's the symmetric key
+- If `rkey` is absent or parsing fails: use `symmetricKeys[0].key` directly
+  (unchanged Gold behavior)
 
-**Same fix applied to:** `capture_firewalla_packets.py` — the capture tool's
-`_provision_symmetric_key()` function had the same bug. This was likely the
-cause of the Issue 22 user's 3 failed decode attempts (the tool was deriving
-the wrong key on their Gold Plus).
+**Same fix applied to:** `capture_firewalla_packets.py` — both group-poll
+paths now check for `rkey`.
 
 ### 9.2 Reverted `mtype` from outer envelope
 
 **Finding:** The `mtype: "msg"` field was added in 1.1.7-beta.1 based on APK
 string analysis of `wx3.d()`. However, that string is the **inner** encrypted
 message structure, not the outer envelope. Neither captured phone trace shows
-`mtype` in the outer envelope. The APK's `y2.java` does add it via
-`c.put("mtype", "msg")`, but the box accepts messages without it.
+`mtype` in the outer envelope.
 
 **Fix:** Removed `_RAW_MESSAGE_MTYPE_KEY` and the `"mtype": "msg"` field from
 the outer payload in `client.py`.
@@ -479,11 +484,11 @@ include:
 - `embeddedOps`: `latest24MainNetworkEvents` with event filters for
   `system_reboot`, `dualwan_state`, `wan_state`
 
-### 9.4 Debug logging for group JSON
+### 9.4 Diagnostic output in capture tool
 
-**Fix:** Added debug logging in `auth.py` that logs whether each group has
-`xname` and how many `symmetricKeys` entries it has. Also logs when two-tier
-key wrapping is activated and when fallback occurs.
+**Fix:** Added diagnostic output to `capture_firewalla_packets.py` that
+reports group fields (including `rkey` presence), key derivation path, and
+derived key length/prefix.
 
 ---
 
@@ -495,8 +500,5 @@ key wrapping is activated and when fallback occurs.
    Gold-working box returns 192KB (full runtime data) on the first POST?
 3. Why does the GP-failing phone send 7 POSTs before SSE while the
    Gold-working phone sends 1?
-4. Does the `rkeyts` field matter for message acceptance?
-5. Are there cloud-brokered pairing paths that use a different key derivation
+4. Are there cloud-brokered pairing paths that use a different key derivation
    than the standard path?
-6. Does the Gold box's cloud response contain `xname`? (Debug logging added
-   in 1.1.8-alpha.1 will answer this on next pairing.)

--- a/docs/PAIRING_AUDIT.md
+++ b/docs/PAIRING_AUDIT.md
@@ -1,0 +1,502 @@
+# Firewalla Local pairing audit
+
+## Purpose
+
+This document captures the known and observed behavior of the Firewalla local
+Encipher pairing protocol across multiple sources:
+
+- captured phone traffic (working Gold box)
+- captured phone traffic (failing Gold Plus box — safe reports only, decryption
+  failed)
+- decompiled Android APK v1.69.1
+- current Home Assistant integration code
+
+It is a working document meant to identify gaps, track findings, and guide
+next steps.
+
+---
+
+## Sources
+
+| Source | Label | Box | Status |
+| --- | --- | --- | --- |
+| `issue_22_chads_gold/phone_redacted.json` | Gold-working | Gold (original) | Fully decrypted ✅ |
+| `phone_decoded_issue22_v2.json` | GP-failing | Gold Plus | Decryption failed (all CRC errors) ❌ |
+| APK `wx3.java` | APK-wx3 | — | Decompiled |
+| APK `y2.java` | APK-y2 | — | Decompiled |
+| APK `n03.java` | APK-n03 | — | Decompiled |
+| Integration `client.py` | HA-client | — | Running code |
+
+---
+
+## 1. Outer envelope (HTTP POST body)
+
+### Observed
+
+| Field | Gold-working | GP-failing | APK (`wx3.c`) | HA 1.1.6 | HA 1.1.7-beta.1 |
+| --- | --- | --- | --- | --- | --- |
+| `message` | ✅ encrypted | ✅ encrypted | ✅ `put("message", m)` | ✅ | ✅ |
+| `timestamp` | ✅ float | ✅ int | ✅ `System.currentTimeMillis()/1000` | ✅ int | ✅ int |
+| `mtype` | ❌ absent | ❌ absent | ✅ `put("mtype", "msg")` in **caller** (`y2.java`) | ❌ absent | ✅ "msg" |
+| `rkeyts` | ❌ absent | ✅ present | ✅ conditional on `jSONObject2.optLong("ts")` | ❌ absent | ❌ absent |
+
+### Key findings
+
+1. The APK's `wx3.c()` builds `{timestamp, message}`. The **caller** `y2.java`
+   adds `mtype: "msg"` afterwards. So the phone app DOES send `mtype` in the
+   outer envelope — but neither of our captured phone traces show it.
+
+2. The `rkeyts` field is present in the GP-failing capture but absent from the
+   Gold-working capture. This is set by the phone app based on box metadata
+   (`n73.y0.optLong("ts")`). It is not something we control — it's a
+   box-reported value.
+
+3. **The `mtype` commit was based on the APK string analysis, not on captured
+   traffic.** The string `,\"compressMode\":1}, \"mtype\":\"msg\"}` found in
+   `wx3.d()` was interpreted as the outer envelope, but it is actually the
+   **inner** encrypted message structure (the nested JSON before encryption).
+   The outer `mtype` is added by `y2.java` via `c.put("mtype", "msg")` where
+   `c` is the outer JSON object.
+
+4. **Both our working Gold and the failing GP phone connections succeed without
+   `mtype` in the outer envelope.** The APK code sends it, but the actual
+   captured traffic does not (or the decode tool is not capturing it). This
+   makes `mtype` an unlikely root cause.
+
+---
+
+## 2. Inner message envelope (encrypted payload)
+
+### Observed structure
+
+| Field | Phone (Gold) | Our HA | APK (`wx3.d`) |
+| --- | --- | --- | --- |
+| `mtype` | `"msg"` | `"msg"` | `"msg"` ✅ |
+| `type` | `"jsondata"` | `"jsondata"` | `"jsondata"` ✅ |
+| `msg` | `""` | `""` | `""` ✅ |
+| `from` | `"iPhone"` | device name | `"Android"` ✅ (intentional) |
+| `obj` | present | present | present ✅ |
+| `appInfo` | present | present | present ✅ |
+| `compressMode` | `1` | `1` | `1` ✅ |
+
+### `obj` structure
+
+| Sub-field | Phone | Our HA |
+| --- | --- | --- |
+| `type` | `"jsonmsg"` | `"jsonmsg"` ✅ |
+| `id` | UUID | UUID ✅ |
+| `mtype` | `"init"` | `"init"` ✅ |
+| `target` | `"0.0.0.0"` | `"0.0.0.0"` ✅ |
+| `data` | varies | varies |
+
+### `appInfo` structure
+
+| Field | Phone (Gold) | Our HA |
+| --- | --- | --- |
+| `deviceName` | `"iPhone"` | `"Firewalla-Local-HA-v1"` |
+| `appID` | `"com.rottiesoft.circle"` | `"com.rottiesoft.circle"` ✅ |
+| `platform` | `"ios"` | `sys.platform` |
+| `timezone` | `"America/New_York"` | user timezone |
+| `language` | `"en"` | `"en"` ✅ |
+| `version` | `"1.69.1-71"` | `"1.68.89"` ⚠️ outdated |
+| `eid` | redacted | our eid |
+| `ios` | `"26.5-0"` | ❌ absent |
+
+---
+
+## 3. Init message sequence
+
+### Gold-working
+
+| Step | Time | Direction | Content | Size | Response |
+| --- | --- | --- | --- | --- | --- |
+| 1 | T+0s | POST | simple init: `{get, COMMAND_TIMEOUT}` | 677B | 200 (192KB) |
+| 2 | T+5s | POST | full init: `{dapOps, fwapcOps, embeddedOps}` | 1609B | 200 (197KB) |
+| 3 | T+11s | GET | SSE (encrypted in URL) | 0B | 200 (13KB) |
+| 4 | T+11s | GET | SSE (encrypted in URL) | 0B | 200 (26KB) |
+| 5 | T+16s | POST | full init (repeat) | 1601B | 200 (197KB) |
+
+### GP-failing (safe report only — decryption failed)
+
+| Step | Time | Direction | Content | Size | Response |
+| --- | --- | --- | --- | --- | --- |
+| 1 | T+0s | POST | ? | 624B | 200 (378B) |
+| 2 | T+5s | POST | ? | 629B | 200 (378B) |
+| 3 | T+5s | POST | ? | 621B | 200 (378B) |
+| 4 | T+6s | POST | ? | 623B | 200 (378B) |
+| 5 | T+6s | POST | ? | 622B | 200 (378B) |
+| 6 | T+6s | POST | ? | 623B | 200 (378B) |
+| 7 | T+7s | POST | ? | 624B | 200 (378B) |
+| 8 | T+7s | GET | SSE | 0B | 200 (970B) |
+| 9 | T+7s | GET | SSE | 0B | 200 (970B) |
+| 10 | T+7s | GET | SSE | 0B | 200 (5900B) |
+| 11 | T+7s | POST | full init | 1647B | 200 (414KB) |
+
+### HA current (1.1.6)
+
+| Step | Direction | Content | Size | Response |
+| --- | --- | --- | --- | --- |
+| 1 | POST | simple init: `{COMMAND_TIMEOUT, get}` | 657B | 412 (12B) |
+| 2-22 | POST | (same message × 21) | 657B | 412 (12B) |
+
+### Key differences
+
+1. **Gold-working response sizes:** The first POST returns 192KB (full runtime
+   data). The box is immediately ready.
+
+2. **GP-failing response sizes:** The first 7 POSTs return only 378B (small
+   acknowledgments). The box is not returning full data until the 11th POST.
+
+3. **GP-failing sends 7 POSTs before SSE** — the Gold-working sends 1 POST
+   before SSE. This suggests the GP box requires more handshake messages.
+
+4. **HA sends identical messages on retry** — the phone never repeats the same
+   message. Each POST has different content (different sizes: 624, 629, 621,
+   623, 622, 623, 624).
+
+---
+
+## 4. fwapcOps and embeddedOps
+
+### Phone (Gold-working) init message 2
+
+```json
+{
+  "fwapcOps": [
+    {"key": "stationControls", "method": "GET", "path": "/config/stations"},
+    {"key": "switchTopology", "method": "GET", "path": "/status/wired_station"},
+    {"key": "switchInfo", "method": "GET", "path": "/status/switch"},
+    {"key": "fwapcCountry", "method": "GET", "path": "/config/country"}
+  ],
+  "embeddedOps": [
+    {
+      "item": "events",
+      "key": "latest24MainNetworkEvents",
+      "target": "0.0.0.0",
+      "value": {
+        "min": <timestamp>,
+        "reverse": true,
+        "parse_json": true,
+        "filters": [
+          {"event_type": "action", "sub_type": "system_reboot"},
+          {"event_type": "state", "sub_type": "dualwan_state"},
+          {"event_type": "state", "sub_type": "wan_state"}
+        ]
+      }
+    }
+  ],
+  "dapOps": [
+    {"key": "dapInfo", "method": "GET", "path": "/info"}
+  ],
+  "get": "0.0.0.0",
+  "value": {}
+}
+```
+
+### Our HA
+
+```json
+{
+  "dapOps": [
+    {"key": "dapInfo", "method": "GET", "path": "/info"}
+  ],
+  "fwapcOps": [
+    {"key": "stationControls", "method": "GET", "path": "/config/stations"}
+  ],
+  "get": "0.0.0.0",
+  "value": {}
+}
+```
+
+### Gaps
+
+- Missing 3 `fwapcOps`: `switchTopology`, `switchInfo`, `fwapcCountry`
+- Missing `embeddedOps` entirely (events query for latest 24h network events)
+- The `n03.n()` APK method confirms the phone sends all of these
+
+---
+
+## 5. `rkeyts` origin
+
+The `rkeyts` value in the outer envelope comes from the APK source:
+
+```java
+// wx3.java - c() method
+JSONObject jSONObject2 = n73Var.y0;
+long optLong = jSONObject2 != null ? jSONObject2.optLong("ts") : 0L;
+if (optLong > 0) {
+    jSONObject.put("rkeyts", optLong);
+}
+
+// y2.java - case 2 (local message send)
+JSONObject c = wx3Var.c(n73Var);
+c.put("mtype", "msg");
+JSONObject jSONObject = n73Var.y0;
+if ((jSONObject != null ? jSONObject.optLong("ts") : 0L) == 0) {
+    c.put("rkeyts", 1);
+}
+```
+
+The `rkeyts` is a box-level timestamp from `n73.y0.ts`. If the box has no `ts`,
+the app sends `rkeyts: 1`. This is a sync/replay-prevention mechanism, not
+something we can control. The presence of `rkeyts` in the GP-failing capture
+and its absence in the Gold-working capture is a box firmware difference.
+
+---
+
+## 6. `mtype` in outer envelope — origin
+
+The `mtype` commit was based on analysis of the APK `wx3.d()` method:
+
+```java
+// wx3.d() — builds the inner encrypted message string
+sb.append(",\"compressMode\":1}, \"mtype\":\"msg\"}");
+```
+
+This string was interpreted as the outer envelope format, but it is actually
+the **inner** message structure. The outer `mtype` is added by `y2.java`:
+
+```java
+// y2.java — case 2, after calling wx3.c()
+JSONObject c = wx3Var.c(n73Var);   // builds {timestamp, message}
+c.put("mtype", "msg");              // adds mtype to outer
+```
+
+The APK confirms the phone app sends `mtype` in the outer envelope. However,
+**neither captured phone trace shows it.** Possible explanations:
+
+1. The decode tool's pcap reassembly loses the outermost JSON layer.
+2. The phone's `okhttp` library sends the outer envelope differently than raw
+   JSON.
+3. The box accepts messages both with and without `mtype`, and the phone
+   stopped sending it in a newer app version.
+
+---
+
+## 7. Key provisioning — the unresolved issue
+
+Three capture attempts from the GP-failing user all produced "Invalid padding
+bytes" on every message. The provisioning succeeds (writes a key file), but
+the key cannot decrypt any captured traffic. This is the central unresolved
+issue.
+
+### Possible explanations
+
+1. **The provisioning flow returns a key that doesn't match the box.** This is
+   the leading theory. On Gold, the same code returns a matching key.
+
+2. **The QR code is consumed by provisioning, and the phone's fresh QR creates
+   a different key.** But the symmetric key is supposed to be per-box, not
+   per-client. If it were per-client, our working Gold capture would also fail.
+
+3. **The user's Npcap/scapy setup is still not correctly parsing the pcap.**
+   But the user tried 3 times with different approaches, and the second attempt
+   used the updated batch file.
+
+4. **The box invalidates the key between provisioning and phone pairing.** The
+   provisioning runs first, then the phone pairs under a fresh QR. If the key
+   rotates, the provisioning key would be stale.
+
+---
+
+## 8. APK provisioning flow — symmetric key extraction
+
+### Cloud login response parsing (`z73.m21307g`)
+
+The cloud login response contains a `groups` array. Each group is parsed into
+an `n73` object via `n73.m15460I()`:
+
+```java
+// n73.m15460I() — parses group JSON from cloud
+this.f22533K = jSONObject.getString("info");      // encrypted box info
+this.f22534X = jSONObject.getString("xname");     // RSA-encrypted symmetric key
+
+// Parse symmetricKeys array
+JSONArray jSONArray = jSONObject.getJSONArray("symmetricKeys");
+for (int i = 0; i < length; i++) {
+    ue3 ue3Var = new ue3();
+    ue3Var.m18976a(jSONArray.getJSONObject(i));
+    arrayList.add(ue3Var);
+}
+
+// Decrypt box info to get model
+JSONObject jSONObject2 = new JSONObject(
+    s97.m18101c(this.f22533K, m15456E().substring(0, 32))
+);
+```
+
+### `ue3` — symmetric key entry
+
+Each `symmetricKeys` array entry has:
+- `key` (`f33132a`) — the RSA-encrypted symmetric key
+- `rkey` (`f33133b`) — a rotation key reference
+- `gid`, `expires`, `effective`, `createdAt`, `name`, `eid`, `inb`
+
+### `m15456E()` — get decryption key
+
+```java
+public String m15456E() {
+    if (this.f22530H0.length() > 0) return this.f22530H0;
+    ArrayList arrayList = this.f22541x0;  // symmetricKeys array
+    if (arrayList.isEmpty()) return Strings.EMPTY;
+    String m18106q = s97.m18106q(
+        ((ue3) arrayList.get(0)).f33132a,  // first symmetricKey's "key" field
+        s97.f29914K                         // RSA private key
+    );
+    this.f22530H0 = m18106q;
+    return m18106q;
+}
+```
+
+This RSA-decrypts the first `symmetricKeys[0].key` using the app's RSA private
+key (`s97.f29914K`).
+
+### `m15457F()` — get the symmetric key for local communication
+
+```java
+public String m15457F() {
+    String str = this.f22535Y;
+    if (str != null) return str;                    // cached value
+
+    qc3 qc3Var = this.f22536Z;
+    if (qc3Var != null) {
+        // PATH A: use locally stored box config key
+        this.f22535Y = qc3Var.f27093b;
+    } else {
+        // PATH B: decrypt xname using the RSA-decrypted symmetric key
+        this.f22535Y = s97.m18101c(
+            this.f22534X,              // xname (AES-encrypted symmetric key)
+            m15456E().substring(0, 32) // first 32 bytes of RSA-decrypted key
+        );
+    }
+    return this.f22535Y;
+}
+```
+
+### Two key derivation paths
+
+**PATH A** (`qc3` exists): The key comes from a locally stored box config
+object (`qc3.f27093b`). This is used when the box has already been paired and
+the key is cached locally.
+
+**PATH B** (`qc3` is null): The key is derived by:
+1. RSA-decrypting `symmetricKeys[0].key` → get the intermediate key
+2. Taking the first 32 bytes of that intermediate key
+3. AES-decrypting `xname` using that 32-byte key with zero IV
+
+### Our HA integration's approach
+
+Our HA code does:
+1. RSA-decrypt `symmetricKeys[0].key` → get the symmetric key
+2. Use that key directly for AES encryption
+
+**The difference:** Our code uses the RSA-decrypted `symmetricKeys[0].key`
+directly as the AES key. The APK uses it as an **intermediate key** — it takes
+only the first 32 bytes and then uses that to AES-decrypt `xname`, which yields
+the actual symmetric key.
+
+### This could be the root cause
+
+If `symmetricKeys[0].key` and `xname` are both present in the cloud response,
+the APK uses `xname` (PATH B) to derive the actual key. Our code uses
+`symmetricKeys[0].key` directly. On Gold, these might produce the same result
+(if `xname` is absent or the key is short enough). On Gold Plus, they might
+differ.
+
+### What about `rkeyts`?
+
+The `rkeyts` field comes from `n73.f22542y0` (the box metadata JSON object).
+This is populated from the init response, not from the cloud login. The
+presence of `rkeyts` in the GP-failing capture suggests the box has a `ts`
+value in its metadata that the Gold box doesn't have. This is a box state
+difference, not a provisioning difference.
+
+### Cloud-brokered pairing scenarios
+
+The APK shows multiple pairing paths:
+
+1. **Standard pairing** (`ProgressDialog.pairing()`): cloud login → rendezvous →
+   group poll → extract key from `symmetricKeys`/`xname`
+
+2. **Migration pairing** (`ProgressDialog.migrate()`): used when upgrading from
+   an older box. Copies settings from source box to target box. The key may
+   come from the source box's local config (`qc3`) rather than from the cloud.
+
+3. **Bluetooth pairing** (`PairingHelper.tryBindBluetooth`): uses Bluetooth to
+   establish initial connection. May bypass cloud rendezvous entirely.
+
+4. **Simple mode pairing** (`RestoreFromBackupDialog`): restores from cloud
+   backup. May use a different key derivation path.
+
+The standard pairing path (path 1) is what our HA code implements. If some
+boxes require a different path (e.g., migration), the key derivation would
+differ.
+
+---
+
+## 9. Fixes applied in 1.1.8-alpha.1
+
+### 9.1 Two-tier key derivation (`xname` support)
+
+**Root cause:** The cloud provisioning response contains a `symmetricKeys` array
+where each entry's `key` field is RSA-encrypted. On older boxes (Gold), the
+RSA-decrypted key IS the final symmetric key. On newer boxes (Gold Plus, Gold
+SE), the RSA-decrypted key is a **Key-Encryption Key (KEK)** — the actual
+symmetric key is AES-CBC encrypted inside a separate `xname` field in the group
+JSON.
+
+**Fix:** `extract_group_credentials()` in `auth.py` now checks for `xname`:
+- If present: RSA-decrypt `symmetricKeys[0].key` → take first 32 bytes →
+  AES-decrypt `xname` → that's the actual symmetric key
+- If absent: use the RSA-decrypted key directly (unchanged Gold behavior)
+- Falls back gracefully on decryption errors
+
+**Same fix applied to:** `capture_firewalla_packets.py` — the capture tool's
+`_provision_symmetric_key()` function had the same bug. This was likely the
+cause of the Issue 22 user's 3 failed decode attempts (the tool was deriving
+the wrong key on their Gold Plus).
+
+### 9.2 Reverted `mtype` from outer envelope
+
+**Finding:** The `mtype: "msg"` field was added in 1.1.7-beta.1 based on APK
+string analysis of `wx3.d()`. However, that string is the **inner** encrypted
+message structure, not the outer envelope. Neither captured phone trace shows
+`mtype` in the outer envelope. The APK's `y2.java` does add it via
+`c.put("mtype", "msg")`, but the box accepts messages without it.
+
+**Fix:** Removed `_RAW_MESSAGE_MTYPE_KEY` and the `"mtype": "msg"` field from
+the outer payload in `client.py`.
+
+### 9.3 Aligned init message with phone flow
+
+**Finding:** The phone's full init message includes 4 `fwapcOps` entries and
+an `embeddedOps` events query. Our HA code only sent 1 `fwapcOps` entry and
+no `embeddedOps`.
+
+**Fix:** Updated `async_get_pairing_runtime_init_payload()` in `client.py` to
+include:
+- `fwapcOps`: `stationControls`, `switchTopology`, `switchInfo`, `fwapcCountry`
+- `embeddedOps`: `latest24MainNetworkEvents` with event filters for
+  `system_reboot`, `dualwan_state`, `wan_state`
+
+### 9.4 Debug logging for group JSON
+
+**Fix:** Added debug logging in `auth.py` that logs whether each group has
+`xname` and how many `symmetricKeys` entries it has. Also logs when two-tier
+key wrapping is activated and when fallback occurs.
+
+---
+
+## 10. Open questions
+
+1. Why does the APK send `mtype` in the outer envelope but neither captured
+   phone trace shows it?
+2. Why does the GP-failing box return 378B responses (small acks) while the
+   Gold-working box returns 192KB (full runtime data) on the first POST?
+3. Why does the GP-failing phone send 7 POSTs before SSE while the
+   Gold-working phone sends 1?
+4. Does the `rkeyts` field matter for message acceptance?
+5. Are there cloud-brokered pairing paths that use a different key derivation
+   than the standard path?
+6. Does the Gold box's cloud response contain `xname`? (Debug logging added
+   in 1.1.8-alpha.1 will answer this on next pairing.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,14 @@ filterwarnings = [
 [tool.ruff]
 line-length = 88
 target-version = "py314"
+exclude = [
+    ".tmp",
+    ".captures",
+    ".artifacts",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+]
 
 [tool.ruff.lint]
 select = ["ASYNC", "B", "C4", "E", "F", "I", "RUF", "SIM", "UP"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-firewalla-local"
-version = "1.1.7-beta.1"
+version = "1.1.8-alpha.1"
 description = "Local-first Home Assistant custom integration for Firewalla"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,12 +46,19 @@ exclude = [
 [tool.ruff.lint]
 select = ["ASYNC", "B", "C4", "E", "F", "I", "RUF", "SIM", "UP"]
 
+[tool.ruff.lint.per-file-ignores]
+"custom_components/firewalla_local/device_tracker.py" = ["I001"]
+
 [tool.mypy]
 python_version = "3.14"
 strict = true
 warn_unused_ignores = true
 show_error_codes = true
 files = ["custom_components/firewalla_local"]
+
+[[tool.mypy.overrides]]
+module = "homeassistant.components.device_tracker"
+ignore_errors = true
 
 [tool.pylint.main]
 ignore-paths = [

--- a/tools/support/capture_firewalla_packets.py
+++ b/tools/support/capture_firewalla_packets.py
@@ -346,13 +346,20 @@ async def _provision_symmetric_key(
                     group_eid = group.get("eid")
                     group_aid = group.get("aid")
                     sym_keys = group.get("symmetricKeys")
-                    has_xname = bool(group.get("xname"))
+                    has_rkey = bool(
+                        sym_keys
+                        and isinstance(sym_keys, list)
+                        and len(sym_keys) > 0
+                        and isinstance(sym_keys[0], dict)
+                        and sym_keys[0].get("rkey")
+                    )
                     print(
                         f"  Found matching group: gid={gid}, "
                         f"eid={'present' if group_eid else 'absent'}, "
                         f"aid={'present' if group_aid else 'absent'}, "
-                        f"symmetricKeys={len(sym_keys) if isinstance(sym_keys, list) else 0}, "
-                        f"xname={'present' if has_xname else 'absent'}"
+                        f"symmetricKeys="
+                        f"{len(sym_keys) if isinstance(sym_keys, list) else 0}, "
+                        f"rkey={'present' if has_rkey else 'absent'}"
                     )
                     if not isinstance(group_eid, str) or not group_eid:
                         continue
@@ -366,27 +373,27 @@ async def _provision_symmetric_key(
                     key_cipher = first_key.get("key")
                     if not isinstance(key_cipher, str) or not key_cipher:
                         continue
-                    intermediate_key = _rsa_decrypt_base64(key_cipher, private_pem)
-                    # Two-tier key wrapping: if xname is present, the
-                    # intermediate key is a KEK used to AES-decrypt xname
-                    xname = group.get("xname")
-                    if isinstance(xname, str) and xname:
-                        print(
-                            "  Group has xname field; deriving key via "
-                            "two-tier wrapping"
-                        )
+                    symmetric_key = _rsa_decrypt_base64(key_cipher, private_pem)
+                    # rkey rotation key: APK's n73.m15464y() tries
+                    # symmetricKeys[0].rkey.key first, then falls back
+                    rkey_raw = first_key.get("rkey")
+                    if isinstance(rkey_raw, str) and rkey_raw:
                         try:
-                            symmetric_key = _aes256_cbc_decrypt_from_base64(
-                                xname, intermediate_key[:32]
-                            )
-                        except ValueError, UnicodeDecodeError:
-                            print("  xname decryption failed; using direct key")
-                            symmetric_key = intermediate_key
-                    else:
-                        print("  No xname field; using direct RSA-decrypted key")
-                        symmetric_key = intermediate_key
+                            rkey_payload = json.loads(rkey_raw)
+                            rkey_cipher = rkey_payload.get("key")
+                            if isinstance(rkey_cipher, str) and rkey_cipher:
+                                print(
+                                    "  Group has rkey rotation key; "
+                                    "deriving key from rkey"
+                                )
+                                symmetric_key = _rsa_decrypt_base64(
+                                    rkey_cipher, private_pem
+                                )
+                        except ValueError, TypeError, json.JSONDecodeError:
+                            print("  rkey parsing failed; using direct key")
                     print(
-                        f"  Derived symmetric key: {len(symmetric_key)} chars, "
+                        f"  Derived symmetric key: "
+                        f"{len(symmetric_key)} chars, "
                         f"prefix={symmetric_key[:8]}..."
                     )
                     return _ProvisioningResult(
@@ -428,12 +435,19 @@ async def _provision_symmetric_key(
                         group_eid = group.get("eid")
                         group_aid = group.get("aid")
                         sym_keys = group.get("symmetricKeys")
-                        has_xname = bool(group.get("xname"))
+                        has_rkey = bool(
+                            sym_keys
+                            and isinstance(sym_keys, list)
+                            and len(sym_keys) > 0
+                            and isinstance(sym_keys[0], dict)
+                            and sym_keys[0].get("rkey")
+                        )
                         print(
                             f"  Found matching group (login fallback): "
                             f"gid={gid}, "
-                            f"symmetricKeys={len(sym_keys) if isinstance(sym_keys, list) else 0}, "
-                            f"xname={'present' if has_xname else 'absent'}"
+                            f"symmetricKeys="
+                            f"{len(sym_keys) if isinstance(sym_keys, list) else 0}, "
+                            f"rkey={'present' if has_rkey else 'absent'}"
                         )
                         if not isinstance(group_eid, str) or not group_eid:
                             continue
@@ -447,25 +461,25 @@ async def _provision_symmetric_key(
                         key_cipher = first_key.get("key")
                         if not isinstance(key_cipher, str) or not key_cipher:
                             continue
-                        intermediate_key = _rsa_decrypt_base64(key_cipher, private_pem)
-                        xname = group.get("xname")
-                        if isinstance(xname, str) and xname:
-                            print(
-                                "  Group has xname field; deriving key via "
-                                "two-tier wrapping"
-                            )
+                        symmetric_key = _rsa_decrypt_base64(key_cipher, private_pem)
+                        rkey_raw = first_key.get("rkey")
+                        if isinstance(rkey_raw, str) and rkey_raw:
                             try:
-                                symmetric_key = _aes256_cbc_decrypt_from_base64(
-                                    xname, intermediate_key[:32]
-                                )
-                            except ValueError, UnicodeDecodeError:
-                                print("  xname decryption failed; using direct key")
-                                symmetric_key = intermediate_key
-                        else:
-                            print("  No xname field; using direct RSA-decrypted key")
-                            symmetric_key = intermediate_key
+                                rkey_payload = json.loads(rkey_raw)
+                                rkey_cipher = rkey_payload.get("key")
+                                if isinstance(rkey_cipher, str) and rkey_cipher:
+                                    print(
+                                        "  Group has rkey rotation key; "
+                                        "deriving key from rkey"
+                                    )
+                                    symmetric_key = _rsa_decrypt_base64(
+                                        rkey_cipher, private_pem
+                                    )
+                            except ValueError, TypeError, json.JSONDecodeError:
+                                print("  rkey parsing failed; using direct key")
                         print(
-                            f"  Derived symmetric key: {len(symmetric_key)} chars, "
+                            f"  Derived symmetric key: "
+                            f"{len(symmetric_key)} chars, "
                             f"prefix={symmetric_key[:8]}..."
                         )
                         return _ProvisioningResult(

--- a/tools/support/capture_firewalla_packets.py
+++ b/tools/support/capture_firewalla_packets.py
@@ -346,6 +346,14 @@ async def _provision_symmetric_key(
                     group_eid = group.get("eid")
                     group_aid = group.get("aid")
                     sym_keys = group.get("symmetricKeys")
+                    has_xname = bool(group.get("xname"))
+                    print(
+                        f"  Found matching group: gid={gid}, "
+                        f"eid={'present' if group_eid else 'absent'}, "
+                        f"aid={'present' if group_aid else 'absent'}, "
+                        f"symmetricKeys={len(sym_keys) if isinstance(sym_keys, list) else 0}, "
+                        f"xname={'present' if has_xname else 'absent'}"
+                    )
                     if not isinstance(group_eid, str) or not group_eid:
                         continue
                     if not isinstance(group_aid, str) or not group_aid:
@@ -358,7 +366,29 @@ async def _provision_symmetric_key(
                     key_cipher = first_key.get("key")
                     if not isinstance(key_cipher, str) or not key_cipher:
                         continue
-                    symmetric_key = _rsa_decrypt_base64(key_cipher, private_pem)
+                    intermediate_key = _rsa_decrypt_base64(key_cipher, private_pem)
+                    # Two-tier key wrapping: if xname is present, the
+                    # intermediate key is a KEK used to AES-decrypt xname
+                    xname = group.get("xname")
+                    if isinstance(xname, str) and xname:
+                        print(
+                            "  Group has xname field; deriving key via "
+                            "two-tier wrapping"
+                        )
+                        try:
+                            symmetric_key = _aes256_cbc_decrypt_from_base64(
+                                xname, intermediate_key[:32]
+                            )
+                        except ValueError, UnicodeDecodeError:
+                            print("  xname decryption failed; using direct key")
+                            symmetric_key = intermediate_key
+                    else:
+                        print("  No xname field; using direct RSA-decrypted key")
+                        symmetric_key = intermediate_key
+                    print(
+                        f"  Derived symmetric key: {len(symmetric_key)} chars, "
+                        f"prefix={symmetric_key[:8]}..."
+                    )
                     return _ProvisioningResult(
                         symmetric_key=symmetric_key,
                         gid=gid,
@@ -398,6 +428,13 @@ async def _provision_symmetric_key(
                         group_eid = group.get("eid")
                         group_aid = group.get("aid")
                         sym_keys = group.get("symmetricKeys")
+                        has_xname = bool(group.get("xname"))
+                        print(
+                            f"  Found matching group (login fallback): "
+                            f"gid={gid}, "
+                            f"symmetricKeys={len(sym_keys) if isinstance(sym_keys, list) else 0}, "
+                            f"xname={'present' if has_xname else 'absent'}"
+                        )
                         if not isinstance(group_eid, str) or not group_eid:
                             continue
                         if not isinstance(group_aid, str) or not group_aid:
@@ -410,7 +447,27 @@ async def _provision_symmetric_key(
                         key_cipher = first_key.get("key")
                         if not isinstance(key_cipher, str) or not key_cipher:
                             continue
-                        symmetric_key = _rsa_decrypt_base64(key_cipher, private_pem)
+                        intermediate_key = _rsa_decrypt_base64(key_cipher, private_pem)
+                        xname = group.get("xname")
+                        if isinstance(xname, str) and xname:
+                            print(
+                                "  Group has xname field; deriving key via "
+                                "two-tier wrapping"
+                            )
+                            try:
+                                symmetric_key = _aes256_cbc_decrypt_from_base64(
+                                    xname, intermediate_key[:32]
+                                )
+                            except ValueError, UnicodeDecodeError:
+                                print("  xname decryption failed; using direct key")
+                                symmetric_key = intermediate_key
+                        else:
+                            print("  No xname field; using direct RSA-decrypted key")
+                            symmetric_key = intermediate_key
+                        print(
+                            f"  Derived symmetric key: {len(symmetric_key)} chars, "
+                            f"prefix={symmetric_key[:8]}..."
+                        )
                         return _ProvisioningResult(
                             symmetric_key=symmetric_key,
                             gid=gid,


### PR DESCRIPTION
This pull request introduces support for Firewalla group key rotation ("rkey") handling, improves diagnostics for group key provisioning, and expands the set of pairing operations and event filters. It also bumps the package version to 1.1.8-alpha.1. The most important changes are grouped below:

Related to #22 and #14 

### Group key rotation (rkey) support

* Added logic to handle the "rkey" (rotation key) field in group symmetric key provisioning: if present, the rkey is used to derive the symmetric key, matching the logic in the official APK. This is implemented in both `custom_components/firewalla_local/api/auth.py` and `tools/support/capture_firewalla_packets.py`. [[1]](diffhunk://#diff-cfa05ddcefa9b099a540bf99debf61eaf49586d8e7e575d46323c01ded78ba78R65) [[2]](diffhunk://#diff-cfa05ddcefa9b099a540bf99debf61eaf49586d8e7e575d46323c01ded78ba78R373-R389) [[3]](diffhunk://#diff-511a5b5867901c3701781777132aa801af6acef135860516bc040aeb863b4a1cR377-R398) [[4]](diffhunk://#diff-511a5b5867901c3701781777132aa801af6acef135860516bc040aeb863b4a1cR465-R484)

### Diagnostics and logging improvements

* Enhanced the provisioning script to print detailed diagnostics about found groups, including whether `eid`, `aid`, `symmetricKeys`, and `rkey` are present, for both main and fallback group searches. [[1]](diffhunk://#diff-511a5b5867901c3701781777132aa801af6acef135860516bc040aeb863b4a1cR349-R363) [[2]](diffhunk://#diff-511a5b5867901c3701781777132aa801af6acef135860516bc040aeb863b4a1cR438-R451)

### Pairing and event filter enhancements

* Added new pairing operation keys and event filter constants (such as `embeddedOps`, `latest24MainNetworkEvents`, and event subtypes for system reboot and WAN state) to `custom_components/firewalla_local/api/client.py`.
* Expanded the initial pairing payload to include new endpoints (`/status/wired_station`, `/status/switch`, `/config/country`) and a new embeddedOps event filter for the latest 24 hours of main network events, filtered by event type and subtype.

### Minor cleanup

* Removed the unused `_RAW_MESSAGE_MTYPE_KEY` from `api/client.py` and its usage in the local message payload. [[1]](diffhunk://#diff-6f0f34e6f7600b33fac3b655d201469cba2422831c28567427d89eb66718c862L57) [[2]](diffhunk://#diff-6f0f34e6f7600b33fac3b655d201469cba2422831c28567427d89eb66718c862L369)

### Version bump

* Updated the version to `1.1.8-alpha.1` in both `manifest.json` and `pyproject.toml`. [[1]](diffhunk://#diff-5839a5201f0acd106bd803dffd506cf394aa2aef82256af5c24b33ff7f2b6373L12-R12) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7)