### PR TITLE
Fix: Re-enable integration-disabled tracker entities and update version

### DIFF
--- a/custom_components/firewalla_local/device_tracker.py
+++ b/custom_components/firewalla_local/device_tracker.py
@@ -102,12 +102,11 @@ class FirewallaDeviceTracker(
 
     def find_device_entry(self) -> dr.DeviceEntry | None:
         """Return the tracked-client device entry for this tracker."""
-        return dr.async_get(self.hass).async_get_device(
-            identifiers={
-                self._entry.runtime_data.integration_manager.build_tracked_client_device_identifier(
-                    self._mac
-                )
-            }
+        return dr.async_get(self.hass).async_get_device_by_identifier(
+            self._entry.runtime_data.integration_manager.build_tracked_client_device_identifier(
+                self._mac
+            ),
+            self._entry.entry_id,
         )
 
     @property

--- a/custom_components/firewalla_local/managers/integration_manager.py
+++ b/custom_components/firewalla_local/managers/integration_manager.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Final, cast
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_registry import RegistryEntryDisabler
 
 from ..const import (
     CONF_LICENSE,
@@ -2424,7 +2425,7 @@ class FirewallaIntegrationManager(FirewallaBaseManager):
     async def async_reconcile_device_tracker_entities(
         self, selected_macs: tuple[str, ...]
     ) -> None:
-        """Remove stale device-tracker entity entries for deselected clients."""
+        """Remove stale and re-enable integration-disabled tracker entities."""
         entity_registry = er.async_get(self.coordinator.hass)
         expected_unique_ids = {
             self.build_entity_unique_id(
@@ -2446,6 +2447,10 @@ class FirewallaIntegrationManager(FirewallaBaseManager):
             if not entity_entry.unique_id.endswith(f"_{ENTITY_SUFFIX_DEVICE_TRACKER}"):
                 continue
             if entity_entry.unique_id in expected_unique_ids:
+                if entity_entry.disabled_by == RegistryEntryDisabler.INTEGRATION:
+                    entity_registry.async_update_entity(
+                        entity_entry.entity_id, disabled_by=None
+                    )
                 continue
 
             entity_registry.async_remove(entity_entry.entity_id)

--- a/custom_components/firewalla_local/manifest.json
+++ b/custom_components/firewalla_local/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/ccpk1/firewalla-local-ha/issues",
   "loggers": ["custom_components.firewalla_local"],
   "requirements": ["cryptography>=44.0.0"],
-  "version": "1.3.0-beta.1"
+  "version": "1.3.0-beta.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-firewalla-local"
-version = "1.3.0-beta.1"
+version = "1.3.0-beta.2"
 description = "Local-first Home Assistant custom integration for Firewalla"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/tests/components/firewalla_local/test_device_tracker.py
+++ b/tests/components/firewalla_local/test_device_tracker.py
@@ -57,12 +57,11 @@ def _tracked_client_device(
     hass: HomeAssistant, entry, mac: str
 ) -> dr.DeviceEntry | None:
     """Return the tracked-client device for one selected MAC."""
-    return dr.async_get(hass).async_get_device(
-        identifiers={
-            entry.runtime_data.integration_manager.build_tracked_client_device_identifier(
-                mac
-            )
-        }
+    return dr.async_get(hass).async_get_device_by_identifier(
+        entry.runtime_data.integration_manager.build_tracked_client_device_identifier(
+            mac
+        ),
+        entry.entry_id,
     )
 
 
@@ -178,8 +177,8 @@ async def test_device_tracker_exposes_state_and_attributes(
     )
     tracker_entry = _device_tracker_registry_entry(hass, entry.entry_id)
     client_device = _tracked_client_device(hass, entry, "AA:BB:CC:DD:EE:FF")
-    router_device = dr.async_get(hass).async_get_device(
-        identifiers={(DOMAIN, "license-123")}
+    router_device = dr.async_get(hass).async_get_device_by_identifier(
+        (DOMAIN, "license-123"), entry.entry_id
     )
 
     assert client_device is not None
@@ -500,11 +499,11 @@ async def test_device_tracker_unique_ids_are_entry_scoped(
     second_client_device = _tracked_client_device(
         hass, second_entry, "AA:BB:CC:DD:EE:FF"
     )
-    first_router_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "license-123")}
+    first_router_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "license-123"), first_entry.entry_id
     )
-    second_router_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "license-456")}
+    second_router_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "license-456"), second_entry.entry_id
     )
 
     assert len(tracker_entries) == 2

--- a/tests/components/firewalla_local/test_device_tracker.py
+++ b/tests/components/firewalla_local/test_device_tracker.py
@@ -10,6 +10,7 @@ from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_registry import RegistryEntryDisabler
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.firewalla_local.const import (
@@ -519,3 +520,53 @@ async def test_device_tracker_unique_ids_are_entry_scoped(
         hass.states.get(entity_entry.entity_id).state
         for entity_entry in tracker_entries
     } == {STATE_NOT_HOME}
+
+
+async def test_device_tracker_reenables_integration_disabled_entity(
+    hass: HomeAssistant,
+) -> None:
+    """Test a previously integration-disabled tracker entity is re-enabled."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="license-123",
+        title="Firewalla (192.168.200.1)",
+        data={
+            CONF_LICENSE: "license-123",
+            CONF_HOST: "192.168.200.1",
+            CONF_GID: "gid-123",
+            CONF_EID: "eid-123",
+            CONF_AID: "aid-123",
+            CONF_SYMMETRIC_KEY: "symmetric-key",
+        },
+        options={
+            CONF_DEVICE_TRACKERS: ["AA:BB:CC:DD:EE:FF"],
+            CONF_DEVICE_TRACKER_AWAY_WINDOW: 15,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    entity_registry = er.async_get(hass)
+    entity_registry.async_get_or_create(
+        "device_tracker",
+        DOMAIN,
+        f"{entry.entry_id}_AA:BB:CC:DD:EE:FF_device_tracker",
+        config_entry=entry,
+        disabled_by=RegistryEntryDisabler.INTEGRATION,
+    )
+
+    with (
+        patch(
+            "custom_components.firewalla_local.api.client.FirewallaApiClient.async_get_runtime_init_payload",
+            new=AsyncMock(return_value=_runtime_payload()),
+        ),
+        patch(
+            "custom_components.firewalla_local.api.client.FirewallaApiClient.build_runtime_snapshot",
+            return_value=_snapshot_with_hosts(_box_host()),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    tracker_entry = _device_tracker_registry_entry(hass, entry.entry_id)
+    assert tracker_entry.disabled_by is None
+    assert tracker_entry.entity_id.startswith("device_tracker.")

--- a/tests/components/firewalla_local/test_init.py
+++ b/tests/components/firewalla_local/test_init.py
@@ -288,8 +288,8 @@ async def test_setup_entry_creates_runtime_sync_button(hass: HomeAssistant) -> N
     assert button_state.attributes[ATTR_INTEGRATION] == DOMAIN
 
     device_registry = dr.async_get(hass)
-    router_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "license-123")}
+    router_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "license-123"), entry.entry_id
     )
     assert router_device is not None
     assert button_entry.device_id == router_device.id
@@ -825,11 +825,11 @@ async def test_setup_multiple_entries_create_distinct_license_devices(
         await hass.async_block_till_done()
 
     device_registry = dr.async_get(hass)
-    first_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "license-123")}
+    first_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "license-123"), first_entry.entry_id
     )
-    second_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "license-456")}
+    second_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "license-456"), second_entry.entry_id
     )
 
     assert first_device is not None
@@ -926,7 +926,12 @@ async def test_deselecting_device_tracker_removes_client_device_and_entity(
     assert entity_registry.async_get_entity_id(
         "device_tracker", DOMAIN, tracker_unique_id
     )
-    assert device_registry.async_get_device(identifiers={client_identifier}) is not None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            client_identifier, entry.entry_id
+        )
+        is not None
+    )
 
     with (
         patch(
@@ -951,7 +956,12 @@ async def test_deselecting_device_tracker_removes_client_device_and_entity(
         entity_registry.async_get_entity_id("device_tracker", DOMAIN, tracker_unique_id)
         is None
     )
-    assert device_registry.async_get_device(identifiers={client_identifier}) is None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            client_identifier, entry.entry_id
+        )
+        is None
+    )
 
 
 async def test_unloading_device_tracker_entry_preserves_registry_for_reload(
@@ -1035,7 +1045,9 @@ async def test_unloading_device_tracker_entry_preserves_registry_for_reload(
     assert entity_id is not None
     entity_entry = entity_registry.async_get(entity_id)
     assert entity_entry is not None
-    client_device = device_registry.async_get_device(identifiers={client_identifier})
+    client_device = device_registry.async_get_device_by_identifier(
+        client_identifier, entry.entry_id
+    )
     assert client_device is not None
     assert entity_entry.device_id == client_device.id
     assert hass.states.get(entity_id) is not None
@@ -1053,7 +1065,9 @@ async def test_unloading_device_tracker_entry_preserves_registry_for_reload(
     assert unloaded_entry is not None
     assert unloaded_entry.device_id == client_device.id
 
-    unloaded_device = device_registry.async_get_device(identifiers={client_identifier})
+    unloaded_device = device_registry.async_get_device_by_identifier(
+        client_identifier, entry.entry_id
+    )
     assert unloaded_device is not None
 
     with (


### PR DESCRIPTION
What changed:
- in async_reconcile_device_tracker_entities, re-enable selected tracker
  entities that were disabled by the integration (disabled_by == INTEGRATION)
- add a test proving a previously integration-disabled tracker entity is
  re-enabled on setup

Why:
- HA 2026.8 ScannerEntity disables trackers by default when its MAC-based
  device lookup fails; tracked-client devices here are keyed by an
  entry-scoped identifier, so trackers created before the 1.2.0
  entity_registry_enabled_default override stay disabled forever because
  async_get_or_create never touches disabled_by on existing entries
- this leaves the tracked-client device present but with no presence entity,
  as reported in https://github.com/ccpk1/firewalla-local-ha/issues/31
  
  What changed:
- replace device_registry.async_get_device(identifiers={...}) with
  async_get_device_by_identifier(identifier, config_entry_id) in
  device_tracker.find_device_entry and the device-tracker/init tests

Why:
- HA 2026.8+ deprecates async_get_device because device identifiers and
  connections are no longer unique across config entries; the new
  async_get_device_by_identifier scopes the lookup to one config entry,
  which matches how tracked-client and router devices are keyed here
- fixes CI failures on the newer HA core