### PR TITLE
fix(network): collect bridge and wlan interface categories (per-network names/ports)

### DIFF
--- a/custom_components/firewalla_local/manifest.json
+++ b/custom_components/firewalla_local/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/ccpk1/firewalla-local-ha/issues",
   "loggers": ["custom_components.firewalla_local"],
   "requirements": ["cryptography>=44.0.0"],
-  "version": "1.3.0-beta.2"
+  "version": "1.3.0-beta.3"
 }

--- a/custom_components/firewalla_local/utils/network.py
+++ b/custom_components/firewalla_local/utils/network.py
@@ -60,6 +60,8 @@ _RAW_VLAN_CATEGORY: Final = "vlan"
 _RAW_WIREGUARD_CATEGORY: Final = "wireguard"
 _RAW_AMNEZIAWG_CATEGORY: Final = "amneziawg"
 _RAW_OPENVPN_CATEGORY: Final = "openvpn"
+_RAW_BRIDGE_CATEGORY: Final = "bridge"
+_RAW_WLAN_CATEGORY: Final = "wlan"
 _NETWORK_KIND_BY_INTERFACE_CATEGORY: Final = {
     _RAW_PHY_CATEGORY: FirewallaNetworkKind.WAN,
     _RAW_BOND_CATEGORY: FirewallaNetworkKind.LAN,
@@ -67,6 +69,13 @@ _NETWORK_KIND_BY_INTERFACE_CATEGORY: Final = {
     _RAW_WIREGUARD_CATEGORY: FirewallaNetworkKind.VPN,
     _RAW_AMNEZIAWG_CATEGORY: FirewallaNetworkKind.VPN,
     _RAW_OPENVPN_CATEGORY: FirewallaNetworkKind.VPN,
+    # Router-Mode boxes segment their LANs either as a LAG ``bond`` or as
+    # per-network ``bridge`` interfaces (each carrying direct ports and/or
+    # tagged VLAN members). Both are LAN networks.
+    _RAW_BRIDGE_CATEGORY: FirewallaNetworkKind.LAN,
+    # A ``wlan`` entry is a wireless WAN uplink (the box joins a Wi-Fi
+    # network as a client), so it is a WAN only when ``meta.type == "wan"``.
+    _RAW_WLAN_CATEGORY: FirewallaNetworkKind.WAN,
 }
 
 
@@ -215,15 +224,37 @@ def _collect_wan_status_fallback(
             _collect_wan_status_fallback(nested_value, networks)
 
 
+def _bridge_member_interface_names(data: dict[str, object]) -> set[str]:
+    """Return interface names referenced as members by any bridge."""
+    raw_network_config = data.get(_RAW_NETWORK_CONFIG_KEY)
+    if not isinstance(raw_network_config, dict):
+        return set()
+    raw_interfaces = raw_network_config.get(_RAW_INTERFACE_KEY)
+    if not isinstance(raw_interfaces, dict):
+        return set()
+
+    member_names: set[str] = set()
+    raw_bridges = raw_interfaces.get(_RAW_BRIDGE_CATEGORY)
+    if not isinstance(raw_bridges, dict):
+        return member_names
+    for raw_entry in raw_bridges.values():
+        if not isinstance(raw_entry, dict):
+            continue
+        for member in _normalized_string_tuple(raw_entry.get(_RAW_INTF_KEY)):
+            member_names.add(member)
+    return member_names
+
+
 def build_network_inventory(data: dict[str, object]) -> tuple[FirewallaNetwork, ...]:
     """Return the unified network identities from a raw init payload.
 
     Networks are discovered from the ``networkConfig.interface`` registry,
-    which is category-keyed (``phy``/``bond``/``vlan``/``wireguard``/
-    ``amneziawg``/``openvpn``). The category key drives the network kind.
-    Names prefer the registry ``meta.name``, then ``networkProfiles``
-    display-name fields, then the interface name. WAN identities missing
-    from the registry fall back to ``networkMonitorData.wanStatus``.
+    which is category-keyed (``phy``/``bond``/``bridge``/``vlan``/
+    ``wireguard``/``amneziawg``/``openvpn``). The category key drives the
+    network kind. Names prefer the registry ``meta.name``, then
+    ``networkProfiles`` display-name fields, then the interface name. WAN
+    identities missing from the registry fall back to
+    ``networkMonitorData.wanStatus``.
     """
     networks: dict[str, FirewallaNetwork] = {}
 
@@ -236,6 +267,18 @@ def build_network_inventory(data: dict[str, object]) -> tuple[FirewallaNetwork, 
                 if not isinstance(raw_category, dict):
                     continue
                 _collect_network_interface_entries(raw_category, kind, networks)
+
+    # A VLAN referenced by a bridge's ``intf`` is transport for that bridge
+    # (e.g. ``eth3.101`` tagging the Guest bridge), not a standalone network;
+    # only VLANs no bridge references are user-facing VLAN networks.
+    bridge_member_interfaces = _bridge_member_interface_names(data)
+    for network_id in [
+        network_id
+        for network_id, network in networks.items()
+        if network.kind is FirewallaNetworkKind.VLAN
+        and network.interface_name in bridge_member_interfaces
+    ]:
+        networks.pop(network_id)
 
     # Normalize names from networkProfiles for the same uuids where the registry
     # did not expose a friendlier display name.
@@ -334,10 +377,12 @@ def _enrich_network_ports(
 ) -> None:
     """Resolve per-network physical ports from the interface registry.
 
-    A physical WAN port (``phy``) is the interface itself (its device name).
-    A bond lists its members in ``intf``. A VLAN references its parent
-    interface in ``intf`` (``bond0``); its real ports are the parent's members.
-    VPNs carry no ports.
+    A physical WAN port (``phy``/``wlan``) is the interface itself (its
+    device name). A bond/bridge lists its member interfaces in ``intf``
+    (direct ports and/or tagged VLAN members). A VLAN references its parent
+    interface in ``intf`` (``bond0``/``eth3``); its real ports are the
+    parent's members. VPNs carry no ports. Each member is dereferenced
+    through parent chains (bridge → VLAN → physical port) to concrete ports.
     """
     raw_network_config = data.get(_RAW_NETWORK_CONFIG_KEY)
     if not isinstance(raw_network_config, dict):
@@ -361,15 +406,24 @@ def _enrich_network_ports(
             parent_members[interface_name] = direct
 
     def resolve_members(interface_name: str) -> tuple[str, ...]:
-        """Return the concrete member ports for one interface reference."""
+        """Return the concrete member ports for one interface reference.
+
+        A member may itself be a parent reference (a bond/bridge, or a tagged
+        VLAN interface like ``eth3.101`` whose parent is ``eth3``), so each
+        member is dereferenced recursively to the physical port set.
+        """
         direct = parent_members.get(interface_name)
         if not direct:
             return ()
-        # A single-string intf is a parent reference (e.g. bond0); dereference
-        # it to that parent's members when they exist.
-        if len(direct) == 1 and parent_members.get(direct[0]):
-            return parent_members[direct[0]]
-        return direct
+        resolved: list[str] = []
+        for member in direct:
+            nested = parent_members.get(member)
+            if nested:
+                resolved.extend(nested)
+            else:
+                resolved.append(member)
+        # Deduplicate while preserving order.
+        return tuple(dict.fromkeys(resolved))
 
     for network in networks.values():
         interface_name = network.interface_name
@@ -377,7 +431,7 @@ def _enrich_network_ports(
             continue
 
         if network.kind is FirewallaNetworkKind.WAN:
-            # A phy WAN is itself the port.
+            # A phy/wlan WAN is itself the port.
             ports: tuple[str, ...] = (interface_name,)
         else:
             ports = resolve_members(interface_name)

--- a/docs/REVERSE_ENGINEERING_WORKFLOW.md
+++ b/docs/REVERSE_ENGINEERING_WORKFLOW.md
@@ -803,12 +803,19 @@ The unified registry is `networkConfig.interface`, keyed by **category**. The
 category key is the source of the granular `network_kind` discriminator
 (`lan`/`vlan`/`vpn`/`wan`) — it is **not** the box's coarse raw `type` field.
 
+Router-Mode boxes segment their LANs one of two ways: as a **LAG `bond`** to a
+managed switch (VLANs ride on the bond) or as per-network **`bridge`**
+interfaces that carry direct ports and/or tagged VLAN members directly. Both
+are LAN networks; the reverse-engineered captures below cover both layouts.
+
 | App screen | `networkConfig.interface` category | `network_kind` | Notes |
 | --- | --- | --- | --- |
-| LAN (`LAN-MGMT`) | `bond` | `lan` | bond of `eth2`+`eth3` |
-| VLAN (`VLAN60 IOT`, `VLAN90 GUEST/DMZ`, …) | `vlan` | `vlan` | entry `vid` = VLAN id; `intf` = parent bond |
+| LAN (`LAN-MGMT`) | `bond` | `lan` | bond of `eth2`+`eth3`; VLANs ride on the bond (`bond0.10`) |
+| LAN (`Guest`, `Home`, `Mgmt`, …) | `bridge` | `lan` | per-network bridge; `intf` lists direct ports and/or tagged VLAN members (e.g. `br1` Guest → `eth3.101`) |
+| VLAN (`VLAN60 IOT`, `VLAN90 GUEST/DMZ`, …) | `vlan` | `vlan` | entry `vid` = VLAN id; `intf` = parent bond. A VLAN **referenced by a bridge's `intf`** is transport for that bridge and is **not** surfaced as its own network |
 | VPN (`AmneziaWG`, `OpenVPN`, `WireGuard`) | `amneziawg` / `openvpn` / `wireguard` | `vpn` | `wgPeers`/`awgPeers` are per-peer hosts, **not** VPN networks |
 | WAN (`WAN-ONE`) | `phy` | `wan` | only a `phy` entry whose `meta.type == "wan"`; unnamed `phy` ports (eth1/2/3) are hardware, not networks |
+| WAN (wireless uplink) | `wlan` | `wan` | only when `meta.type == "wan"`; the box joins a Wi-Fi network as a client (`wpaSupplicant`), so it is a wireless WAN uplink, not a wireless LAN AP |
 
 Each entry carries a `meta` block: `name` (display name), `type` (`lan`/`wan`
 only — coarse), `uuid`. The `network_kind` is derived from the category key so
@@ -821,7 +828,7 @@ only — coarse), `uuid`. The `network_kind` is derived from the category key so
 | Name | `networkConfig.interface.<cat>.<name>.meta.name` → `networkProfiles` display fields | `FirewallaNetwork.name` | (entity name) |
 | Kind | `networkConfig.interface` category key | `FirewallaNetwork.kind` | `network_kind` |
 | VLAN ID | `networkConfig.interface.vlan.<name>.vid` | `FirewallaNetwork.vlan_id` | `vlan_id` |
-| Ethernet ports | `phy` WAN = its device name; `bond` = `intf` members; `vlan` = dereference `intf` parent to members; VPN = none | `FirewallaNetwork.ports` | `ports` |
+| Ethernet ports | `phy`/`wlan` WAN = its device name; `bond`/`bridge` = `intf` members; `vlan` = dereference `intf` parent to members; every member is dereferenced through parent chains (bridge → VLAN → physical port); VPN = none | `FirewallaNetwork.ports` | `ports` |
 | IPv4 address | `networkProfiles[uuid].ipv4` (bare) / `item=intf` `ipv4` | `FirewallaNetwork.ipv4_addresses` | `ipv4_addresses` |
 | IPv4 subnet | `networkProfiles[uuid].ipv4Subnet(s)` (CIDR) | `FirewallaNetwork.ipv4_subnets` | `ipv4_subnets` |
 | IPv6 address | `item=intf` → `ipv6` | `FirewallaNetwork.ipv6_addresses` | `ipv6_addresses` |
@@ -865,6 +872,13 @@ WAN monthly totals also remain on the System Status `current_wan_usage` /
 - Keep entity naming kind-agnostic (no `ipv4`/`ipv6` in the unique-id or
   translation keys); the display name renders the kind acronym + network name
   (`Firewalla VLAN VLAN10 CORE Status`).
+- A VLAN interface that a bridge references in `intf` is **transport** (e.g.
+  `eth3.101` tags the `Guest` bridge), not a standalone network. Only VLANs no
+  bridge references are user-facing `vlan` networks. This prevents duplicate
+  entities for the same physical network (bridge + its tagging VLAN).
+- `wlan` is a wireless WAN uplink only when `meta.type == "wan"`; a non-`wan`
+  `wlan` entry (e.g. an AP-facing interface) is skipped, mirroring the `phy`
+  WAN guard.
 
 ## Inventory-confirmed durable rule findings
 
@@ -2221,6 +2235,57 @@ Implementation impact:
 - a host-delete service should send a `cmd` message with
   `item: "host:delete"` and `value: {"mac": "<host-mac>"}` targeting
   `0.0.0.0`, matching the existing manager-owned mutation pattern
+
+### Finding 23: Router-Mode LANs can be `bridge` interfaces (not only `bond`)
+
+Scenario:
+
+- a user's Gold SE in Router Mode reported network entities with wrong names
+  (`br0`, `br1`, …) and empty ports; a diagnostic download showed all LAN
+  networks defined as `bridge` interfaces, and a wireless `wlan` WAN uplink
+- the initial reverse-engineering capture (Finding 5) only documented the
+  `bond` layout (LAN-MGMT as a LAG of `eth2`+`eth3`, VLANs riding `bond0.10`)
+- the new diagnostic proved a second, equally valid Router-Mode topology: LANs
+  defined as per-network `bridge` interfaces carrying direct ports and/or
+  tagged VLAN members directly
+
+Observed local sources (user diagnostic `runtime_init_payload`):
+
+- `networkConfig.interface.bridge` — `br0`..`br4` with `meta.name` = `Mgmt`,
+  `Guest`, `Home`, `VoIP`, `IoT`, `meta.type` = `lan`, and `intf` listing
+  direct ports and/or tagged VLAN members:
+  - `br0` Mgmt → `intf: ["eth2", "eth3"]`
+  - `br1` Guest → `intf: ["eth3.101"]`
+  - `br3` Home → `intf: ["eth3.100"]`
+  - `br2` VoIP → `intf: ["eth1.102", "eth3.102"]`
+  - `br4` IoT → `intf: ["eth3.103"]`
+- `networkConfig.interface.vlan` — `eth3.100`..`eth3.103`, `eth1.102` are the
+  tagged members behind those bridges (`vid`, `intf: "eth3"`/`"eth1"`)
+- `networkConfig.interface.wlan.wlan0` — `meta.name` = `Wireless`,
+  `meta.type` = `wan`, carrying `wpaSupplicant` (SSID/PSK) — a wireless WAN
+  uplink, not a wireless LAN AP
+- `networkConfig.nat` — per-bridge rules `br0-eth0`..`br4-eth0` (each LAN NAT'd
+  out through the WAN `eth0`) — confirms Router Mode (Firewalla does NAT)
+- `networkConfig.dhcp`/`mdns_reflector`/`icmp` — keyed by the bridge interface
+  names (`br0`..`br4`), so advanced options and DHCP are per-bridge
+
+Conclusion:
+
+- Router-Mode boxes define LANs either as a LAG **`bond`** or as per-network
+  **`bridge`** interfaces; both are `lan`-kind networks and must be collected
+- a `bridge`'s `intf` members are dereferenced through parent chains (bridge →
+  tagged VLAN → physical port) to concrete ports, e.g. `br2` VoIP →
+  `eth1`+`eth3`
+- a VLAN interface that a bridge references in `intf` is **transport** for that
+  bridge (e.g. `eth3.101` tags the `Guest` bridge) and is **not** surfaced as
+  its own `vlan` network; only VLANs no bridge references are standalone VLANs
+- a `wlan` entry is a wireless WAN uplink and maps to `wan` **only** when
+  `meta.type == "wan"`; a non-`wan` `wlan` entry is skipped, mirroring the
+  `phy` WAN guard
+- entity `unique_id`s are uuid-based (`network_<uuid>`), and the bridge uuids
+  are identical whether the network is collected from the registry or the
+  `networkProfiles` fallback, so fixing the collection does not churn existing
+  registry entries — only the display name/ports update
 
 ## Capture workflow note
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-firewalla-local"
-version = "1.3.0-beta.2"
+version = "1.3.0-beta.3"
 description = "Local-first Home Assistant custom integration for Firewalla"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/tests/components/firewalla_local/test_integration_manager.py
+++ b/tests/components/firewalla_local/test_integration_manager.py
@@ -670,6 +670,201 @@ def test_get_networks_resolves_physical_ports() -> None:
     assert by_uuid["876e3889-0199-45f3-aeb1-a49c3f38e96e"].ports == ()
 
 
+def test_get_networks_discovers_bridge_and_wlan_categories() -> None:
+    """Test bridge LANs and wireless WAN uplinks are classified correctly.
+
+    Router-Mode boxes segment LANs as ``bridge`` interfaces (carrying direct
+    ports and/or tagged VLAN members), and a ``wlan`` entry is a wireless WAN
+    uplink only when ``meta.type == "wan"``.
+    """
+    snapshot = FirewallaRuntimeSnapshot(
+        appliance_identity=FirewallaApplianceIdentityInput(
+            host="192.168.200.1",
+            group_name="Firewalla",
+            device_name=None,
+            model="gold",
+            serial_number="serial-123",
+            software_version="1.0.0",
+        ),
+        appliance_runtime=FirewallaApplianceRuntimeInput(),
+        policy_rules=(),
+        exception_rule_count=0,
+    )
+    manager = _build_manager(snapshot)
+    manager.coordinator.last_init_payload = {
+        "networkConfig": {
+            "interface": {
+                "phy": {
+                    "eth0": {
+                        "meta": {
+                            "name": "2degrees",
+                            "type": "wan",
+                            "uuid": "8d5a7f20-2923-49a3-8e2b-338f9428a632",
+                        }
+                    },
+                    "eth1": {"meta": {"uuid": "d2a5b1c5-31ca-4d42-8906-09b24e68c5d2"}},
+                    "eth2": {"meta": {"uuid": "27aa9b20-e679-4f78-8c76-791e02a7c2ca"}},
+                    "eth3": {"meta": {"uuid": "47f86e7a-c673-4374-a8a4-0c7b445f5c8d"}},
+                },
+                "wlan": {
+                    "wlan0": {
+                        "meta": {
+                            "name": "Wireless",
+                            "type": "wan",
+                            "uuid": "deadbeef-1111-4222-8333-444455556666",
+                        }
+                    }
+                },
+                "bridge": {
+                    "br1": {
+                        "meta": {
+                            "name": "Guest",
+                            "type": "lan",
+                            "uuid": "aff1d681-981f-4ae4-ba0c-d1620947097b",
+                        },
+                        "intf": ["eth3.101"],
+                    }
+                },
+                "vlan": {
+                    "eth3.101": {
+                        "meta": {
+                            "uuid": "95169e6a-a7c9-4d6a-8e83-6061b4812bf2",
+                        },
+                        "vid": 101,
+                        "intf": "eth3",
+                    }
+                },
+            }
+        }
+    }
+
+    by_uuid = {network.uuid: network for network in manager.get_networks()}
+
+    # The wlan uplink is a WAN, distinct from the phy WAN.
+    assert by_uuid["deadbeef-1111-4222-8333-444455556666"].kind is (
+        FirewallaNetworkKind.WAN
+    )
+    assert by_uuid["deadbeef-1111-4222-8333-444455556666"].name == "Wireless"
+    assert by_uuid["deadbeef-1111-4222-8333-444455556666"].ports == ("wlan0",)
+    # The bridge is a LAN and its tagged VLAN member is transport, so the VLAN
+    # is not surfaced as a separate network.
+    assert by_uuid["aff1d681-981f-4ae4-ba0c-d1620947097b"].kind is (
+        FirewallaNetworkKind.LAN
+    )
+    assert by_uuid["aff1d681-981f-4ae4-ba0c-d1620947097b"].name == "Guest"
+    assert by_uuid["aff1d681-981f-4ae4-ba0c-d1620947097b"].ports == ("eth3",)
+    assert "95169e6a-a7c9-4d6a-8e83-6061b4812bf2" not in by_uuid
+
+
+def test_get_networks_keeps_standalone_vlan_not_referenced_by_bridge() -> None:
+    """Test a standalone VLAN not referenced by any bridge stays a VLAN."""
+    snapshot = FirewallaRuntimeSnapshot(
+        appliance_identity=FirewallaApplianceIdentityInput(
+            host="192.168.200.1",
+            group_name="Firewalla",
+            device_name=None,
+            model="gold",
+            serial_number="serial-123",
+            software_version="1.0.0",
+        ),
+        appliance_runtime=FirewallaApplianceRuntimeInput(),
+        policy_rules=(),
+        exception_rule_count=0,
+    )
+    manager = _build_manager(snapshot)
+    manager.coordinator.last_init_payload = {
+        "networkConfig": {
+            "interface": {
+                "phy": {
+                    "eth0": {
+                        "meta": {
+                            "name": "WAN-ONE",
+                            "type": "wan",
+                            "uuid": "8d5a7f20-2923-49a3-8e2b-338f9428a632",
+                        }
+                    }
+                },
+                "bridge": {
+                    "br1": {
+                        "meta": {
+                            "name": "Guest",
+                            "type": "lan",
+                            "uuid": "aff1d681-981f-4ae4-ba0c-d1620947097b",
+                        },
+                        "intf": ["eth3.101"],
+                    }
+                },
+                "vlan": {
+                    "eth3.101": {
+                        "meta": {
+                            "uuid": "95169e6a-a7c9-4d6a-8e83-6061b4812bf2",
+                        },
+                        "vid": 101,
+                        "intf": "eth3",
+                    },
+                    "eth1.9": {
+                        "meta": {
+                            "name": "DMZ",
+                            "type": "lan",
+                            "uuid": "deadbeef-2222-4222-8333-444455556666",
+                        },
+                        "vid": 9,
+                        "intf": "eth1",
+                    },
+                },
+            }
+        }
+    }
+
+    by_uuid = {network.uuid: network for network in manager.get_networks()}
+
+    # The bridge-referenced VLAN is transport and filtered.
+    assert "95169e6a-a7c9-4d6a-8e83-6061b4812bf2" not in by_uuid
+    # The standalone VLAN is surfaced.
+    assert by_uuid["deadbeef-2222-4222-8333-444455556666"].kind is (
+        FirewallaNetworkKind.VLAN
+    )
+    assert by_uuid["deadbeef-2222-4222-8333-444455556666"].name == "DMZ"
+    assert by_uuid["deadbeef-2222-4222-8333-444455556666"].ports == ("eth1",)
+
+
+def test_get_networks_wan_requires_meta_type_wan() -> None:
+    """Test a wlan entry with a non-wan meta.type is not surfaced as WAN."""
+    snapshot = FirewallaRuntimeSnapshot(
+        appliance_identity=FirewallaApplianceIdentityInput(
+            host="192.168.200.1",
+            group_name="Firewalla",
+            device_name=None,
+            model="gold",
+            serial_number="serial-123",
+            software_version="1.0.0",
+        ),
+        appliance_runtime=FirewallaApplianceRuntimeInput(),
+        policy_rules=(),
+        exception_rule_count=0,
+    )
+    manager = _build_manager(snapshot)
+    manager.coordinator.last_init_payload = {
+        "networkConfig": {
+            "interface": {
+                "wlan": {
+                    "wlan0": {
+                        "meta": {
+                            "name": "Wireless LAN AP",
+                            "type": "lan",
+                            "uuid": "deadbeef-3333-4222-8333-444455556666",
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    networks = manager.get_networks()
+
+    assert {network.uuid for network in networks} == set()
+
+
 @pytest.mark.asyncio
 async def test_async_refresh_network_usage_attaches_totals() -> None:
     """Test usage refresh fetches item=intf and merges totals into networks."""


### PR DESCRIPTION
## Summary

Fixes per-network entities showing wrong names (`br0`, `br1`, …) and empty `ports` for users whose Firewalla defines its LANs as **`bridge`** interfaces (Router Mode with per-network bridges) rather than as a LAG **`bond`**.

A user diagnostic showed a Gold SE with all LANs defined in `networkConfig.interface.bridge` (`br0`..`br4` = `Mgmt`/`Guest`/`Home`/`VoIP`/`IoT`), each carrying direct ports and/or tagged VLAN members. The category→kind map in `utils/network.py` only knew `phy`/`bond`/`vlan`/`wireguard`/`amneziawg`/`openvpn`, so:

- bridges were collected only via the `networkProfiles` fallback with interface-name labels (`br0`, …) and no ports
- per-bridge DHCP and advanced options (mDNS/SSDP Relay, Block ICMP) — all keyed by bridge interface name — were never attached
- a wireless `wlan` WAN uplink was also not collected

This change adds the missing categories and improves port resolution.

## What's included

- **`bridge` → `LAN`** category: Router-Mode per-network bridges are now collected with their `meta.name`, ports, DHCP, and advanced options
- **`wlan` → `WAN`** category (only when `meta.type == "wan"`): the box's wireless WAN uplink (joins a Wi-Fi network as a client via `wpaSupplicant`), mirroring the `phy` WAN guard
- **Port dereferencing through parent chains**: bridge → tagged VLAN → physical port (e.g. `br2` VoIP → `eth1`+`eth3`; `br1` Guest → `eth3`)
- **Bridge-member VLAN filtering**: a VLAN referenced by a bridge's `intf` is transport for that bridge and is no longer surfaced as its own `vlan` network (prevents duplicate entities); standalone VLANs (e.g. `DMZ`) are still surfaced
- **Reverse-engineering doc**: category table/design notes updated and new Finding 23 documenting the `bridge`/`wlan` topology from the diagnostic

## Validation

- [x] `bash ./utils/quick_lint.sh`
- [x] `python -m mypy custom_components/firewalla_local` — 33 files, no issues
- [x] `python -m pytest tests/ -v` — 263 passed (4 new)
- [x] `python -m ruff check .` — clean
- [x] `python -m ruff format .` — clean

Reproduced the fix against the user's actual diagnostic payload: bridge LANs now surface with correct names (`Mgmt`/`Guest`/`Home`/`VoIP`/`IoT`) and correct physical ports, WAN is `2degrees`, standalone `DMZ` VLAN stays a `vlan`, and bridge-member VLANs (`eth3.100`..`eth3.103`, `eth1.102`) are filtered. No focused validation was skipped.

## Release summary

Per-network status entities now correctly name and show ports for Firewalla boxes that define their LANs as bridge interfaces (rather than a single LAG bond). Network names like `Mgmt`, `Guest`, `Home`, `VoIP`, and `IoT` appear correctly, each with its physical ports, DHCP, and advanced options, plus wireless WAN uplinks are surfaced. No manual entity cleanup is needed after upgrade — entity IDs are stable and names update automatically.

## Docs impact

- [ ] No user-facing docs needed
- [ ] README updated
- [ ] User guide updated
- [x] Contributor or support docs updated — `docs/REVERSE_ENGINEERING_WORKFLOW.md` (Finding 23)

## Issue linkage

Related to #21

